### PR TITLE
Dev/logging

### DIFF
--- a/Dockferfile.build
+++ b/Dockferfile.build
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+MAINTAINER The Tusken Raiders "jawa@jamf.com"
+
+RUN apt-get update -y && \
+    apt-get install -y python3-pip python3-dev cron git curl nano
+
+COPY ./requirements.txt /app/requirements.txt
+
+WORKDIR /usr/local/jawa
+
+RUN pip install -r requirements.txt
+
+COPY . /usr/local/jawa
+
+ENTRYPOINT [ "python3" ]
+
+CMD [ "app.py" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Jamf Automation and Webhook Assistant ("JAWA") Version 3.0.3b
+# Jamf Automation and Webhook Assistant ("JAWA") Version 3.0.3b_logging
 
 <p align="center"> <img src="https://github.com/jamf/JAWA/blob/master/static/img/jawa_icon.png" width="384"/> </p>
 

--- a/app.py
+++ b/app.py
@@ -14,23 +14,29 @@ import uuid
 from waitress import serve
 
 from bin.view_modifiers import response
+from bin import logger
 
+logthis = logger.setup_child_logger('app')
+logthis.info(f'this got logged by app.py child')
+logthis.info("JAWA Logger from the main page.")
+logthis.debug("App.py SAYS: this is a Debug Message.")
+logthis.info("App.py SAYS: this is an Info Message.")
 
 def jawa_logger():
-    global logger
+    global oldlogger
     log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
     logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger('jawa')
-    logger.setLevel(logging.INFO)
+    oldlogger = logging.getLogger('jawa')
+    oldlogger.setLevel(logging.INFO)
     handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
     handler.setLevel(logging.INFO)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
 
-    if logger.hasHandlers():
-        logger.handlers.clear()
-    logger.addHandler(handler)
-    return logger
+    if oldlogger.hasHandlers():
+        oldlogger.handlers.clear()
+    oldlogger.addHandler(handler)
+    return oldlogger
 
 
 # Flask logging
@@ -50,13 +56,13 @@ def func():
 
 def main():
     base_dir = os.path.dirname(__file__)
-    jawa_logger().info(f"JAWA initializing...\n Sandcrawler home:  {base_dir}")
+    logthis.info(f"JAWA initializing...\n Sandcrawler home:  {base_dir}")
     environment_setup(base_dir)
     register_blueprints()
     app.secret_key = str(uuid.uuid4())
     app.permanent_session_lifetime = timedelta(minutes=10)
-    serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
-
+    # serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
+    serve(app, url_scheme='http', host='0.0.0.0', port=8000, threads=15)
 
 def environment_setup(project_dir):
     global webhooks_file, cron_file, server_json_file, scripts_directory
@@ -64,7 +70,7 @@ def environment_setup(project_dir):
     cron_file = os.path.abspath(os.path.join(project_dir, 'data', 'cron.json'))
     server_json_file = os.path.abspath(os.path.join(project_dir, 'data', 'server.json'))
     scripts_directory = os.path.abspath(os.path.join(project_dir, 'scripts'))
-    jawa_logger().info(f"Detecting JAWA environment:\n"
+    logthis.info(f"Detecting JAWA environment:\n"
                        f"Webhooks configuration file: {webhooks_file}\n"
                        f"Cron configuration file: {cron_file}\n"
                        f"Server configuration file: {server_json_file}\n"
@@ -106,14 +112,14 @@ def setup():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
     if request.method == 'POST':
-        jawa_logger().debug(f"[{session.get('url')}] {session.get('username')} /setup - POST")
+        logthis.debug(f"[{session.get('url')}] {session.get('username')} /setup - POST")
         server_url = request.form.get('address')
         if not server_url:
             return redirect(url_for('setup'))
         jps_url = request.form.get('jss-lock')
         jps2_check = request.form.get('alternate-jamf')
         jps_url2 = request.form.get('alternate')
-        jawa_logger().info(f"{session.get('username')} made JAWA Setup Changes\n"
+        logthis.info(f"{session.get('username')} made JAWA Setup Changes\n"
                            f"JAWA URL: {server_url}\n"
                            f"Primary JPS: {jps_url}\n"
                            f"Alternate JPS: {jps_url2}\n"
@@ -144,7 +150,7 @@ def setup():
                                success_msg="JAWA Setup Complete!",
                                username=str(escape(session['username'])))
     else:
-        jawa_logger().debug(f"[{session.get('url')}] {session.get('username')} - /setup - GET")
+        logthis.debug(f"[{session.get('url')}] {session.get('username')} - /setup - GET")
         if not os.path.isfile(server_json_file):
             with open(server_json_file, "w") as outfile:
                 server_json = {'jawa_address': '', 'jps_url': '', 'alternate_jps': ''}
@@ -169,13 +175,13 @@ def cleanup():
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
     if request.method != 'POST':
         return {"username": session.get('username'), "scripts_dir": scripts_directory}
-    logger.info(f"[{session.get('url')}] {session.get('username')} is cleaning up scripts...")
+    oldlogger.info(f"[{session.get('url')}] {session.get('username')} is cleaning up scripts...")
     owd = os.getcwd()
     if not os.path.isdir(scripts_directory):
         os.mkdir(scripts_directory)
     os.chdir(scripts_directory)
     for file in glob.glob("*.old"):
-        logger.info(f"[{session.get('url')}] {session.get('username')} removed the script {file}...")
+        oldlogger.info(f"[{session.get('url')}] {session.get('username')} removed the script {file}...")
         os.remove(file)
     os.chdir(owd)
     return redirect(url_for('success'))
@@ -204,7 +210,7 @@ def login():
         session['username'] = request.form['username']
         session['password'] = request.form['password']
 
-        jawa_logger().info(f"[{session.get('url')}] Attempting login for: {session.get('username')}")
+        logthis.info(f"[{session.get('url')}] Attempting login for: {session.get('username')}")
 
         if request.form['password'] == "":
             return redirect(url_for('logout', error_title="Authentication error", error_message="Passwords can't be blank"))
@@ -218,16 +224,16 @@ def login():
             resp.raise_for_status()
 
         except requests.exceptions.HTTPError as err:
-            jawa_logger().info(f"Error occurred: {err}")
+            logthis.info(f"Error occurred: {err}")
             return redirect(url_for('logout', error_title="HTTP Error", error_message=err))
         except requests.exceptions.ConnectTimeout as err:
-            jawa_logger().info(f"Error occurred: {err}")
+            logthis.info(f"Error occurred: {err}")
             return redirect(url_for('logout', error_title="Connection Timeout", error_message=err))
         except requests.exceptions.ConnectionError as err:
-            jawa_logger().info(f"Error occurred: {err}")
+            logthis.info(f"Error occurred: {err}")
             return redirect(url_for('logout', error_title="HTTP Error", error_message=err))
 
-        jawa_logger().info(
+        logthis.info(
             f"[{session.get('url')}] Logging In: " + str(escape(session['username'])))
 
         return redirect(url_for('dashboard'))
@@ -288,7 +294,7 @@ def home():
 def dashboard():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username')} rendering /dashboard.")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} rendering /dashboard.")
     with open(webhooks_file) as webhook_json:
         webhooks_installed = json.load(webhook_json)
     jamf_pro_webhooks = []
@@ -330,7 +336,7 @@ def dashboard():
 
     if not cron_json:
         cron_json = ''
-    jawa_logger().info(f"Total webhooks managed by JAWA: {len(webhooks_installed)}")
+    logthis.info(f"Total webhooks managed by JAWA: {len(webhooks_installed)}")
     if webhook_json == cron_json:
         return redirect(url_for('first_automation'))
     return render_template(
@@ -350,7 +356,7 @@ def dashboard():
 @app.route('/success', methods=['GET', 'POST'])
 def success():
     if 'username' not in session:
-        jawa_logger().info("No user logged in - returning to login page.")
+        logthis.info("No user logged in - returning to login page.")
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
     return render_template(
         'success.html',
@@ -365,7 +371,7 @@ def error():
     error_message = request.args.get('error_message')
     if 'username' not in session:
         return redirect(url_for('logout'))
-    jawa_logger().info(
+    logthis.info(
         f"[{session.get('url')}] {session.get('username').title()} was a victim of a series of accidents, as are we all. (/error)")
     return render_template('error.html', username=session.get('username'), error_message=error_title,
                            error=error_message)
@@ -374,10 +380,10 @@ def error():
 @app.errorhandler(404)
 def page_not_found(error):
     if 'username' in session:
-        jawa_logger().info(
+        logthis.info(
             f"[{session.get('url')}] {session.get('username')} wandered off course  ({request.path}) - redirecting to /dashboard.")
         return redirect(url_for('dashboard'))
-    jawa_logger().info(
+    logthis.info(
         f"An invalid path ({request.path}) was provided and no user is logged in.  Returning login page.")
     return load_home()
 
@@ -387,7 +393,7 @@ def logout():
     error_title = request.args.get('error_title')
     error_message = request.args.get('error_message')
     if session.get('username'):
-        logger.info("Logging Out: " + str(escape(session['username'])))
+        oldlogger.info("Logging Out: " + str(escape(session['username'])))
         session.pop('username', None)
     return load_home(error_title, error_message)
 

--- a/app.py
+++ b/app.py
@@ -6,8 +6,6 @@ from flask import (Flask, request, render_template,
                    session, redirect, url_for, escape)
 import glob
 import json
-import logging
-from logging import handlers
 import os
 import requests
 import uuid
@@ -17,7 +15,7 @@ from bin.view_modifiers import response
 from bin import logger
 
 # Flask logging
-logthis = logger.setup_child_logger('app')
+logthis = logger.setup_child_logger('jawa', 'app')
 error_message = ""
 verify_ssl = True  # Enables Jamf Pro SSL certificate verification
 
@@ -38,8 +36,8 @@ def main():
     register_blueprints()
     app.secret_key = str(uuid.uuid4())
     app.permanent_session_lifetime = timedelta(minutes=10)
-    # serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
     serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
+
 
 def environment_setup(project_dir):
     global webhooks_file, cron_file, server_json_file, scripts_directory
@@ -48,10 +46,10 @@ def environment_setup(project_dir):
     server_json_file = os.path.abspath(os.path.join(project_dir, 'data', 'server.json'))
     scripts_directory = os.path.abspath(os.path.join(project_dir, 'scripts'))
     logthis.info(f"Detecting JAWA environment:\n"
-                       f"Webhooks configuration file: {webhooks_file}\n"
-                       f"Cron configuration file: {cron_file}\n"
-                       f"Server configuration file: {server_json_file}\n"
-                       f"Scripts directory: {scripts_directory}")
+                 f"Webhooks configuration file: {webhooks_file}\n"
+                 f"Cron configuration file: {cron_file}\n"
+                 f"Server configuration file: {server_json_file}\n"
+                 f"Scripts directory: {scripts_directory}")
 
 
 def register_blueprints():
@@ -97,10 +95,10 @@ def setup():
         jps2_check = request.form.get('alternate-jamf')
         jps_url2 = request.form.get('alternate')
         logthis.info(f"{session.get('username')} made JAWA Setup Changes\n"
-                           f"JAWA URL: {server_url}\n"
-                           f"Primary JPS: {jps_url}\n"
-                           f"Alternate JPS: {jps_url2}\n"
-                           f"Alternate enabled?: {jps2_check}")
+                     f"JAWA URL: {server_url}\n"
+                     f"Primary JPS: {jps_url}\n"
+                     f"Alternate JPS: {jps_url2}\n"
+                     f"Alternate enabled?: {jps2_check}")
         new_json = {}
         if server_url != '':
             new_json['jawa_address'] = server_url
@@ -190,7 +188,9 @@ def login():
         logthis.info(f"[{session.get('url')}] Attempting login for: {session.get('username')}")
 
         if request.form['password'] == "":
-            return redirect(url_for('logout', error_title="Authentication error", error_message="Passwords can't be blank"))
+            title = "Authentication error"
+            msg = "Passwords can't be blank"
+            return redirect(url_for('logout', error_title=title, error_message=msg))
         try:
             resp = requests.get(
                 session['url'] + '/JSSResource/activationcode',

--- a/app.py
+++ b/app.py
@@ -16,31 +16,8 @@ from waitress import serve
 from bin.view_modifiers import response
 from bin import logger
 
-logthis = logger.setup_child_logger('app')
-logthis.info(f'this got logged by app.py child')
-logthis.info("JAWA Logger from the main page.")
-logthis.debug("App.py SAYS: this is a Debug Message.")
-logthis.info("App.py SAYS: this is an Info Message.")
-
-# def jawa_logger():
-#     global oldlogger
-#     log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
-#     logging.basicConfig(level=logging.INFO)
-#     oldlogger = logging.getLogger('jawa')
-#     oldlogger.setLevel(logging.INFO)
-#     handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
-#     handler.setLevel(logging.INFO)
-#     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-#     handler.setFormatter(formatter)
-#
-#     if oldlogger.hasHandlers():
-#         oldlogger.handlers.clear()
-#     oldlogger.addHandler(handler)
-#     return oldlogger
-
-
 # Flask logging
-
+logthis = logger.setup_child_logger('app')
 error_message = ""
 verify_ssl = True  # Enables Jamf Pro SSL certificate verification
 
@@ -62,7 +39,7 @@ def main():
     app.secret_key = str(uuid.uuid4())
     app.permanent_session_lifetime = timedelta(minutes=10)
     # serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
-    serve(app, url_scheme='http', host='0.0.0.0', port=8000, threads=15)
+    serve(app, url_scheme='https', host='0.0.0.0', port=8000, threads=15)
 
 def environment_setup(project_dir):
     global webhooks_file, cron_file, server_json_file, scripts_directory
@@ -175,13 +152,13 @@ def cleanup():
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
     if request.method != 'POST':
         return {"username": session.get('username'), "scripts_dir": scripts_directory}
-    oldlogger.info(f"[{session.get('url')}] {session.get('username')} is cleaning up scripts...")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} is cleaning up scripts...")
     owd = os.getcwd()
     if not os.path.isdir(scripts_directory):
         os.mkdir(scripts_directory)
     os.chdir(scripts_directory)
     for file in glob.glob("*.old"):
-        oldlogger.info(f"[{session.get('url')}] {session.get('username')} removed the script {file}...")
+        logthis.info(f"[{session.get('url')}] {session.get('username')} removed the script {file}...")
         os.remove(file)
     os.chdir(owd)
     return redirect(url_for('success'))
@@ -393,7 +370,7 @@ def logout():
     error_title = request.args.get('error_title')
     error_message = request.args.get('error_message')
     if session.get('username'):
-        oldlogger.info("Logging Out: " + str(escape(session['username'])))
+        logthis.info("Logging Out: " + str(escape(session['username'])))
         session.pop('username', None)
     return load_home(error_title, error_message)
 

--- a/app.py
+++ b/app.py
@@ -22,6 +22,25 @@ logthis.info("JAWA Logger from the main page.")
 logthis.debug("App.py SAYS: this is a Debug Message.")
 logthis.info("App.py SAYS: this is an Info Message.")
 
+# def jawa_logger():
+#     global oldlogger
+#     log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
+#     logging.basicConfig(level=logging.INFO)
+#     oldlogger = logging.getLogger('jawa')
+#     oldlogger.setLevel(logging.INFO)
+#     handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
+#     handler.setLevel(logging.INFO)
+#     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+#     handler.setFormatter(formatter)
+#
+#     if oldlogger.hasHandlers():
+#         oldlogger.handlers.clear()
+#     oldlogger.addHandler(handler)
+#     return oldlogger
+
+
+# Flask logging
+
 error_message = ""
 verify_ssl = True  # Enables Jamf Pro SSL certificate verification
 

--- a/app.py
+++ b/app.py
@@ -22,25 +22,6 @@ logthis.info("JAWA Logger from the main page.")
 logthis.debug("App.py SAYS: this is a Debug Message.")
 logthis.info("App.py SAYS: this is an Info Message.")
 
-def jawa_logger():
-    global oldlogger
-    log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
-    logging.basicConfig(level=logging.INFO)
-    oldlogger = logging.getLogger('jawa')
-    oldlogger.setLevel(logging.INFO)
-    handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
-    handler.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-
-    if oldlogger.hasHandlers():
-        oldlogger.handlers.clear()
-    oldlogger.addHandler(handler)
-    return oldlogger
-
-
-# Flask logging
-jawa_logger()
 error_message = ""
 verify_ssl = True  # Enables Jamf Pro SSL certificate verification
 

--- a/bin/load_home.py
+++ b/bin/load_home.py
@@ -1,8 +1,11 @@
+from flask import render_template, session, redirect, url_for
+from glob import escape
 import json
 import os
-from glob import escape
 
-from flask import render_template, session, redirect, url_for
+from bin import logger
+
+logthis = logger.setup_child_logger('jawa', __name__)
 
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
 

--- a/bin/logger.py
+++ b/bin/logger.py
@@ -7,6 +7,7 @@ logger_name = 'jawa'
 log_roll_size = (1048576 * 100)
 log_backupCount = 10
 
+
 def setup_logger(log_name, log_filename):
     # log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
     logging.basicConfig(level=logging.INFO)
@@ -33,7 +34,8 @@ def setup_logger(log_name, log_filename):
 def setup_child_logger(name):
     return logging.getLogger(logger_name).getChild(name)
 
-print('going to create logthis.')
+
+# print('going to create logthis.')
 logthis = setup_logger(logger_name, f'{logger_name}.log')
-print('created logthis.')
-logthis.debug('this got logged by the main logger')
+# print('created logthis.')
+# logthis.debug('this got logged by the main logger')

--- a/bin/logger.py
+++ b/bin/logger.py
@@ -9,7 +9,7 @@ log_backupCount = 10
 
 def setup_logger(log_name, log_filename):
     # log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
-
+    logging.basicConfig(level=logging.INFO)
     log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data'))
     print(f'log_path: {log_path}')
     if not os.path.isdir(log_path):
@@ -26,12 +26,14 @@ def setup_logger(log_name, log_filename):
     #     logger.setLevel(logging.DEBUG)
     # else:
     logger.setLevel(logging.DEBUG)
+    print('created logger.')
     return logger
 
 
 def setup_child_logger(name):
     return logging.getLogger(logger_name).getChild(name)
 
-
+print('going to create logthis.')
 logthis = setup_logger(logger_name, f'{logger_name}.log')
+print('created logthis.')
 logthis.debug('this got logged by the main logger')

--- a/bin/logger.py
+++ b/bin/logger.py
@@ -7,24 +7,6 @@ logger_name = 'jawa'
 log_roll_size = (1048576 * 100)
 log_backupCount = 10
 
-# OLD CODE From Main.py
-# def jawa_logger():
-#     global logger
-#     log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
-#     logging.basicConfig(level=logging.INFO)
-#     logger = logging.getLogger('jawa')
-#     logger.setLevel(logging.INFO)
-#     handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
-#     handler.setLevel(logging.INFO)
-#     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-#     handler.setFormatter(formatter)
-#
-#     if logger.hasHandlers():
-#         logger.handlers.clear()
-#     logger.addHandler(handler)
-#     return logger
-
-
 def setup_logger(log_name, log_filename):
     # log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
 

--- a/bin/logger.py
+++ b/bin/logger.py
@@ -1,0 +1,55 @@
+import logging
+from logging import handlers
+import os
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger_name = 'jawa'
+log_roll_size = (1048576 * 100)
+log_backupCount = 10
+
+# OLD CODE From Main.py
+# def jawa_logger():
+#     global logger
+#     log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
+#     logging.basicConfig(level=logging.INFO)
+#     logger = logging.getLogger('jawa')
+#     logger.setLevel(logging.INFO)
+#     handler = handlers.RotatingFileHandler(log_file, maxBytes=(1048576 * 100), backupCount=10)
+#     handler.setLevel(logging.INFO)
+#     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+#     handler.setFormatter(formatter)
+#
+#     if logger.hasHandlers():
+#         logger.handlers.clear()
+#     logger.addHandler(handler)
+#     return logger
+
+
+def setup_logger(log_name, log_filename):
+    # log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
+
+    log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data'))
+    print(f'log_path: {log_path}')
+    if not os.path.isdir(log_path):
+        os.makedirs(log_path)
+    log_file = os.path.join(log_path, log_filename)
+    print(f'log_file: {log_file}')
+    handler = handlers.RotatingFileHandler(log_file, maxBytes=log_roll_size, backupCount=log_backupCount)
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(log_name)
+    if logger.hasHandlers():
+        logger.handlers.clear()
+    logger.addHandler(handler)
+    # if settings.debug_mode:
+    #     logger.setLevel(logging.DEBUG)
+    # else:
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def setup_child_logger(name):
+    return logging.getLogger(logger_name).getChild(name)
+
+
+logthis = setup_logger(logger_name, f'{logger_name}.log')
+logthis.debug('this got logged by the main logger')

--- a/bin/logger.py
+++ b/bin/logger.py
@@ -4,38 +4,28 @@ import os
 
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger_name = 'jawa'
+default_log_level = logging.INFO
 log_roll_size = (1048576 * 100)
 log_backupCount = 10
 
 
-def setup_logger(log_name, log_filename):
-    # log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'jawa.log'))
-    logging.basicConfig(level=logging.INFO)
+def setup_logger(log_name=logger_name, log_filename=f"{logger_name}.log", log_level=default_log_level):
     log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data'))
-    print(f'log_path: {log_path}')
     if not os.path.isdir(log_path):
         os.makedirs(log_path)
     log_file = os.path.join(log_path, log_filename)
-    print(f'log_file: {log_file}')
     handler = handlers.RotatingFileHandler(log_file, maxBytes=log_roll_size, backupCount=log_backupCount)
     handler.setFormatter(formatter)
     logger = logging.getLogger(log_name)
     if logger.hasHandlers():
         logger.handlers.clear()
     logger.addHandler(handler)
-    # if settings.debug_mode:
-    #     logger.setLevel(logging.DEBUG)
-    # else:
-    logger.setLevel(logging.DEBUG)
-    print('created logger.')
+    logger.setLevel(log_level)
     return logger
 
 
-def setup_child_logger(name):
-    return logging.getLogger(logger_name).getChild(name)
+def setup_child_logger(name_of_logger, name_of_child):
+    return logging.getLogger(name_of_logger).getChild(name_of_child)
 
 
-# print('going to create logthis.')
 logthis = setup_logger(logger_name, f'{logger_name}.log')
-# print('created logthis.')
-# logthis.debug('this got logged by the main logger')

--- a/bin/okta_verification.py
+++ b/bin/okta_verification.py
@@ -1,16 +1,5 @@
-#!/usr/bin/python
-
-from flask import request
-import json
-import sys
-
-
 def verify_new_webhook(challenge):
-    # challenge = sys.argv[2]
-    # verification = request.headers.get('x-okta-verification-challenge')
-    json_text = {f"verification": f"{challenge}"}
-    print(json.dumps(json_text))
-    return json_text
+    return {"verification": f"{challenge}"}
 
 
 def main():

--- a/views/cron_views.py
+++ b/views/cron_views.py
@@ -11,7 +11,6 @@ from flask import (Flask, request, render_template,
 
 from crontab import CronTab
 
-from app import jawa_logger
 from bin import logger
 from bin.view_modifiers import response
 

--- a/views/cron_views.py
+++ b/views/cron_views.py
@@ -12,7 +12,11 @@ from flask import (Flask, request, render_template,
 from crontab import CronTab
 
 from app import jawa_logger
+from bin import logger
 from bin.view_modifiers import response
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
 
 cron_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'cron.json'))
 time_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'time.json'))
@@ -26,7 +30,7 @@ blueprint = Blueprint('cron', __name__)
 def cron_home():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
+    logthis.info(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
     with open(cron_json_file, 'r') as fin:
         cron_json = json.load(fin)
     return {"username": session.get('username'), "cron_list": cron_json}
@@ -36,7 +40,7 @@ def cron_home():
 def new_cron():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
+    logthis.info(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
     days, frequencies, hours = time_definitions()
 
     if request.method != 'POST':
@@ -90,7 +94,7 @@ def new_cron():
     try:
         cron = CronTab(user=True)
     except IOError as err:
-        jawa_logger().info(f"{err}")
+        logthis.info(f"{err}")
         os.remove(script_file)
         return render_template('error.html', error=err, username=session.get('username'))
 
@@ -150,7 +154,7 @@ def new_cron():
     with open(cron_json_file, 'w') as outfile:
         json.dump(data, outfile, indent=4)
     success_msg = f"{session.get('username')} created {cron_name} to run at the frequency:\n {frequency}."
-    jawa_logger().info(f"{success_msg}")
+    logthis.info(f"{success_msg}")
 
     return render_template('success.html',
                            webhooks="success", success_msg=success_msg,
@@ -186,7 +190,7 @@ def time_definitions():
 def delete_cron():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username')} viewed {request.path}")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} viewed {request.path}")
     target_job = request.args.get('target_job')
     with open(cron_json_file) as fin:
         cron_json = json.load(fin)
@@ -214,12 +218,12 @@ def delete_cron():
     try:
         cron = CronTab(user=True)
     except IOError as err:
-        jawa_logger().info(f"{err}")
+        logthis.info(f"{err}")
         return render_template('error.html', error=err, username=session.get('username'))
 
     for job in cron:
         if job.comment == target_job:
-            jawa_logger().info(f"[{session.get('url')}] {session.get('username')} removed cron job {target_job}")
+            logthis.info(f"[{session.get('url')}] {session.get('username')} removed cron job {target_job}")
             cron.remove(job)
             cron.write()
 
@@ -236,7 +240,7 @@ def delete_cron():
 def edit_cron():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username')} viewed {request.path}")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} viewed {request.path}")
     with open(cron_json_file) as fin:
         cron_json = json.load(fin)
     names = []
@@ -246,24 +250,24 @@ def edit_cron():
         if item.get('name') == name:
             description = item.get('description')
     if not name:
-        jawa_logger().info(
+        logthis.info(
             '/cron/edit - Warning: No name provided, redirecting to cron home '
         )
 
         return redirect(url_for('cron.cron_home'))
-    jawa_logger().info(f"{session.get('username').title()} checking for job '{name}' in JAWA's crontab")
+    logthis.info(f"{session.get('username').title()} checking for job '{name}' in JAWA's crontab")
 
     try:
         cron = CronTab(user=True)
     except IOError as err:
-        jawa_logger().info(f"Error accessing crontab - {err}")
+        logthis.info(f"Error accessing crontab - {err}")
         return render_template('error.html', error=err, username=session.get('username'))
 
     check_for_name = [True for job in cron if job.comment == name]
-    jawa_logger().info(f"Name exists? {check_for_name}")
+    logthis.info(f"Name exists? {check_for_name}")
 
     if not check_for_name:
-        jawa_logger().info(f"JAWA is not aware of any job named {name} in JAWA's crontab")
+        logthis.info(f"JAWA is not aware of any job named {name} in JAWA's crontab")
         return redirect(url_for('cron.cron_home'))
 
     if not names:
@@ -285,7 +289,7 @@ def edit_cron():
 
     button_choice = request.form.get('button_choice')
     if button_choice == 'Delete':
-        jawa_logger().info(f"{session.get('username')} is considering deleting a Timed Automation ({name})...")
+        logthis.info(f"{session.get('username')} is considering deleting a Timed Automation ({name})...")
         return redirect(url_for('cron.delete_cron', target_job=name))
 
     for each_cron in cron_json:
@@ -329,7 +333,7 @@ def edit_cron():
         try:
             cron = CronTab(user=True)
         except IOError as err:
-            jawa_logger().info(f"Error accessing crontab - {err}")
+            logthis.info(f"Error accessing crontab - {err}")
             return render_template('error.html', error=err, username=session.get('username'))
 
     for each_job in cron:
@@ -377,7 +381,7 @@ def edit_cron():
     with open(cron_json_file, 'w') as outfile:
         json.dump(cron_json, outfile, indent=4)
     success_msg = f"{session.get('username')} created {new_cron_name} to run at the frequency:  {frequency}."
-    jawa_logger().info(f"{success_msg}")
+    logthis.info(f"{success_msg}")
 
     return render_template('success.html', success_msg=success_msg,
                            webhooks="success",

--- a/views/cron_views.py
+++ b/views/cron_views.py
@@ -1,21 +1,14 @@
-#!/usr/bin/python
-# encoding: utf-8
-import os
-import json
-from time import sleep
-import re
-from werkzeug.utils import secure_filename
-from flask import (Flask, request, render_template,
-                   session, redirect, url_for, escape,
-                   send_from_directory, Blueprint, abort)
-
 from crontab import CronTab
+from flask import (Blueprint, escape, redirect, render_template,
+                   request, session, url_for)
+import json
+import os
+from werkzeug.utils import secure_filename
 
 from bin import logger
 from bin.view_modifiers import response
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 cron_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'cron.json'))
 time_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'time.json'))

--- a/views/custom_webhook.py
+++ b/views/custom_webhook.py
@@ -1,17 +1,15 @@
-import os
-import json
 from collections import defaultdict
+from flask import (Blueprint, escape, redirect, render_template,
+                   request, session, url_for)
+import json
+import os
 from werkzeug.utils import secure_filename
-from flask import (Flask, request, render_template,
-                   session, redirect, url_for, escape,
-                   send_from_directory, Blueprint, abort)
 
-from bin.load_home import load_home
+
 from bin.view_modifiers import response
 from bin import logger
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 blueprint = Blueprint('custom_webhook', __name__, template_folder='templates')
 

--- a/views/custom_webhook.py
+++ b/views/custom_webhook.py
@@ -8,7 +8,6 @@ from flask import (Flask, request, render_template,
 
 from bin.load_home import load_home
 from bin.view_modifiers import response
-from app import jawa_logger
 from bin import logger
 
 logthis = logger.setup_child_logger(__name__)

--- a/views/custom_webhook.py
+++ b/views/custom_webhook.py
@@ -9,6 +9,10 @@ from flask import (Flask, request, render_template,
 from bin.load_home import load_home
 from bin.view_modifiers import response
 from app import jawa_logger
+from bin import logger
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
 
 blueprint = Blueprint('custom_webhook', __name__, template_folder='templates')
 
@@ -43,21 +47,21 @@ def edit_webhook():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
     name = request.args.get('name')
-    jawa_logger().info(f"Checking for custom webhook '{name}'")
+    logthis.info(f"Checking for custom webhook '{name}'")
     with open(webhooks_file) as fin:
         webhooks_json = json.load(fin)
     check_for_name = [True for each_webhook in webhooks_json if each_webhook['name'] == name]
-    jawa_logger().info(f"Name exists? {check_for_name}")
+    logthis.info(f"Name exists? {check_for_name}")
     if not check_for_name:
-        jawa_logger().info(f"JAWA is not aware of any custom webhook named {name}")
+        logthis.info(f"JAWA is not aware of any custom webhook named {name}")
         return redirect(url_for('custom_webhook.custom_webhook'))
     if request.method == 'POST':
         button_choice = request.form.get('button_choice')
         if button_choice == 'Delete':
-            jawa_logger().info(f"{session.get('username')} is considering deleting a custom webhook ({name})...")
+            logthis.info(f"{session.get('username')} is considering deleting a custom webhook ({name})...")
             return redirect(url_for('webhooks.delete_webhook', target_webhook=name))
         for each_webhook in webhooks_json:
-            jawa_logger().info(f"{session.get('username')} is editing a custom webhook ({name})...")
+            logthis.info(f"{session.get('username')} is editing a custom webhook ({name})...")
             if each_webhook['name'] == name:
                 new_custom_name = request.form.get('custom_name')
                 if not new_custom_name:
@@ -112,7 +116,7 @@ def new_webhook():
         description = request.form.get('description')
         if request.form.get('custom_name') != '':
             check = 0
-            jawa_logger().info(f"New webhook name: {request.form.get('custom_name')}")
+            logthis.info(f"New webhook name: {request.form.get('custom_name')}")
 
             with open(webhooks_file, 'r') as json_file:
                 webhooks_json = json.load(json_file)
@@ -137,7 +141,7 @@ def new_webhook():
             os.chdir(owd)
             if check != 0:
                 error_message = "Name already exists!"
-                jawa_logger().info(f"Could not create new webhook. Message: {error_message}")
+                logthis.info(f"Could not create new webhook. Message: {error_message}")
                 return {"error": error_message, "username": session.get('username'), 'name': new_custom_name,
                         'description': description}
             new_webhook_user = request.form.get('username', 'null')

--- a/views/jamf_webhook.py
+++ b/views/jamf_webhook.py
@@ -10,7 +10,6 @@ from flask import (Flask, request, render_template,
 
 from bin.load_home import load_home
 from bin.view_modifiers import response
-from app import jawa_logger
 from bin import logger
 
 logthis = logger.setup_child_logger(__name__)

--- a/views/jamf_webhook.py
+++ b/views/jamf_webhook.py
@@ -209,8 +209,8 @@ def jp_new():
         jamf_id = result.group(1)
         new_link = "{}/webhooks.html?id={}&o=r".format(session['url'], result.group(1))
         logthis.info(f"{session.get('username')} created a new webhook:"
-                           f"Name: {request.form.get('name')}"
-                           f"Jamf link: {new_link}")
+                     f"Name: {request.form.get('name')}"
+                     f"Jamf link: {new_link}")
 
         data = json.load(open(webhooks_file))
         webhook_username = request.form.get('username')
@@ -373,17 +373,17 @@ def edit():
                        f"<content_type>application/json</content_type>" \
                        f"<event>{each_webhook.get('event')}</event>" \
                        f"{auth_xml}" \
-                       f"{extra_xml}"\
+                       f"{extra_xml}" \
                        f"</webhook>"
 
                 full_url = f"{session['url']}/JSSResource/webhooks/id/{each_webhook.get('jamf_id')}"
 
-                logthis.info(f"{session.get('username')} editing the JPS webhook {name}.")
+                logthis.debug(f"{session.get('username')} editing the JPS webhook {name}.")
                 try:
                     webhook_response = requests.put(full_url,
-                                                auth=(session['username'], session['password']),
-                                                headers={'Content-Type': 'application/xml'}, data=data,
-                                                verify=verify_ssl)
+                                                    auth=(session['username'], session['password']),
+                                                    headers={'Content-Type': 'application/xml'}, data=data,
+                                                    verify=verify_ssl)
                 except:
                     error_message = f"The request could not be sent to your Jamf Pro server," \
                                     f"check your network connection."
@@ -391,13 +391,17 @@ def edit():
                                            error_message=error_message,
                                            error="error",
                                            username=str(escape(session['username'])))
-                logthis.info(f"[{webhook_response.status_code}]  {webhook_response.text}")
+                logthis.debug(f"[{webhook_response.status_code}]  {webhook_response.text}")
                 if webhook_response.status_code == 409:
-                    error_message = f"The webhooks name \"{request.form.get('webhook_name')}\" already exists in your Jamf Pro Server."
-                    return redirect(url_for('error', error="Duplicate", error_message=error_message, username=session.get('username')))
+                    error_message = f"The webhooks name \"{name}\" already exists in your Jamf Pro Server."
+                    logthis.info(
+                        f"[{session.get('url')}] {session.get('username').title()} - error editing webhook. {error_message}")
+                    return redirect(url_for('error', error="Duplicate", error_message=error_message,
+                                            username=session.get('username')))
                 elif webhook_response.status_code == 401:
                     error_message = f"{session.get('username').title()} doesn't have privileges to update webhooks." \
                                     f"Check your account privileges in Jamf Pro Settings"
+                    logthis.info(f"[{session.get('url')}] {error_message}")
                     return redirect(url_for('error', error="Insufficient privileges", error_message=error_message,
                                             username=session.get('username')))
                 with open(webhooks_file, 'w') as fout:
@@ -407,8 +411,8 @@ def edit():
                 new_link = f"{format(session.get('url'))}/webhooks.html?id={jamf_id}&o=r"
                 success_msg = "Webhook edited:"
                 logthis.info(f"{session.get('username')} edited a Jamf webhook:"
-                                   f"Name: {request.form.get('name')}"
-                                   f"Jamf link: {new_link}")
+                             f"Name: {name}"
+                             f"Jamf link: {new_link}")
                 return {"webhooks": "success", "smart_group_instructions": smart_group_instructions,
                         "smart_group_notice": smart_group_notice,
                         "new_link": new_link,

--- a/views/jamf_webhook.py
+++ b/views/jamf_webhook.py
@@ -1,19 +1,16 @@
-import os
-import json
 from collections import defaultdict
-import requests
+from flask import (Blueprint, escape, redirect, render_template,
+                   request, session, url_for)
+import json
+import os
 import re
+import requests
 from werkzeug.utils import secure_filename
-from flask import (Flask, request, render_template,
-                   session, redirect, url_for, escape,
-                   send_from_directory, Blueprint, abort)
 
-from bin.load_home import load_home
 from bin.view_modifiers import response
 from bin import logger
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
 webhooks_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'webhooks.json'))
@@ -35,7 +32,6 @@ def jamf_webhook():
         tag = data['tag']
         if tag == "jamfpro":
             jamf_pro_list.append(each_webhook)
-    # print(jamf_pro_list)
 
     return {'username': session.get('username'),
             'jamf_list': jamf_pro_list, 'url': session.get('url')}
@@ -76,7 +72,6 @@ def jp_new():
 
     if request.form.get('webhook_name') != '':
         check = 0
-        print(check)
         if ' ' in request.form.get('webhook_name'):
             error_message = "Single-string name only."
             return render_template('error.html',
@@ -267,9 +262,7 @@ def edit():
         return redirect(url_for('jamf_pro_webhooks.jamf_webhook'))
     # GET
     webhook_info = [each_webhook for each_webhook in webhooks_json if each_webhook['name'] == name]
-    print(webhook_info)
     if request.method == 'POST':
-        # print(name)
         button_choice = request.form.get('button_choice')
         if button_choice == 'Delete':
             return redirect(url_for('webhooks.delete_webhook', target_webhook=name))

--- a/views/log_view.py
+++ b/views/log_view.py
@@ -6,10 +6,15 @@ from time import sleep
 from bin.load_home import load_home
 from bin.view_modifiers import response
 from app import jawa_logger
+from bin import logger
 
 import flask
 from flask import current_app, session, render_template, Blueprint, send_file, request, redirect, url_for
 import os
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
+logthis.info(f'this got logged by {__name__} child')
 
 log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'jawa.log'))
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
@@ -21,7 +26,7 @@ blueprint = Blueprint('log_view', __name__, template_folder='templates')
 def log_home():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
+    logthis.debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
     with open(log_file, 'r') as fin:
         lines = [re.sub('\n', '', line) for line in fin.readlines()]
         lines.reverse()
@@ -33,7 +38,7 @@ def log_home():
 def log_view():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
+    logthis.debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
     with open(log_file, 'r') as fin:
         lines = [re.sub('\n', '', line) for line in fin.readlines()]
         lines.reverse()
@@ -46,7 +51,7 @@ def log_view():
 def stream():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
+    logthis.debug(f"[{session.get('url')}] {session.get('username').title()} viewed {request.path}")
 
     def generate():
         with open(log_file) as f:
@@ -60,7 +65,7 @@ def stream():
 def yield_log():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"/log/yield accessed by {session.get('username') or 'nobody'}")
+    logthis.info(f"/log/yield accessed by {session.get('username') or 'nobody'}")
 
     def inner():
         proc = subprocess.Popen(
@@ -80,7 +85,7 @@ def yield_log():
 def download_logs():
     if 'username' not in session:
         return redirect(url_for('logout', error_title="Session Timed Out", error_message="Please sign in again"))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username')} used {request.path} to download the log.")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} used {request.path} to download the log.")
     timestamp = datetime.now()
-    jawa_logger().info(f"Downloading log file...{timestamp}-jawa.log")
+    logthis.info(f"Downloading log file...{timestamp}-jawa.log")
     return send_file(log_file, as_attachment=True, attachment_filename=f"{datetime.now()}-jawa.log")

--- a/views/log_view.py
+++ b/views/log_view.py
@@ -1,19 +1,16 @@
 from datetime import datetime
+import flask
+from flask import (Blueprint, current_app, escape, redirect, render_template, Response,
+                   request, send_file, session, url_for)
+import os
 import re
 import subprocess
 from time import sleep
 
-from bin.load_home import load_home
 from bin.view_modifiers import response
 from bin import logger
 
-import flask
-from flask import current_app, session, render_template, Blueprint, send_file, request, redirect, url_for
-import os
-
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
-logthis.info(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'jawa.log'))
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
@@ -77,7 +74,7 @@ def yield_log():
             sleep(.1)  # Don't need this just shows the text streaming
             yield line.rstrip().decode() + '<br/>\n'
 
-    return flask.Response(inner(), mimetype='text/html')
+    return Response(inner(), mimetype='text/html')
 
 
 @blueprint.route('/log/download')

--- a/views/log_view.py
+++ b/views/log_view.py
@@ -5,7 +5,6 @@ from time import sleep
 
 from bin.load_home import load_home
 from bin.view_modifiers import response
-from app import jawa_logger
 from bin import logger
 
 import flask

--- a/views/okta_webhook.py
+++ b/views/okta_webhook.py
@@ -1,23 +1,17 @@
 #!/usr/bin/python
 # encoding: utf-8
-import os
-import json
-import glob
-import time
 from collections import defaultdict
-from time import sleep
+import json
+from flask import (Blueprint, escape, redirect, render_template,
+                   request, session, url_for)
+import os
 import requests
-import re
 from werkzeug.utils import secure_filename
-from flask import (Flask, request, render_template,
-                   session, redirect, url_for, escape,
-                   send_from_directory, Blueprint, abort)
 
 from bin.view_modifiers import response
 from bin import logger
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 blueprint = Blueprint('okta_webhook', __name__)
 

--- a/views/okta_webhook.py
+++ b/views/okta_webhook.py
@@ -14,6 +14,10 @@ from flask import (Flask, request, render_template,
                    send_from_directory, Blueprint, abort)
 
 from bin.view_modifiers import response
+from bin import logger
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
 
 blueprint = Blueprint('okta_webhook', __name__)
 
@@ -81,7 +85,7 @@ def okta_new():
     okta_event = request.form.get('event')
     description = request.form.get('description')
     webhook_server_url = server_address + '/hooks/' + okta_name
-    print(webhook_server_url)
+    logthis.info(webhook_server_url)
     owd = os.getcwd()
     os.chdir(scripts_dir)
 
@@ -107,6 +111,7 @@ def okta_new():
     for i in data:
         if str(i['name']) == okta_name:
             error_message = "Name already exists!"
+            logthis.info("okta webhook erorr")
             return render_template('error.html',
                                    error_message=error_message,
                                    error="error",

--- a/views/resource_view.py
+++ b/views/resource_view.py
@@ -2,11 +2,15 @@ import json
 from datetime import datetime
 from flask import current_app, session, redirect, url_for, render_template, Flask, Blueprint, send_file, request
 from app import jawa_logger
+from bin import logger
 import os
 from werkzeug.utils import secure_filename
 
 from bin.load_home import load_home
 from bin.view_modifiers import response
+
+logthis = logger.setup_child_logger(__name__)
+logthis.info(f'this got logged by {__name__} child')
 
 log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'jawa.log'))
 server_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
@@ -25,21 +29,21 @@ def files():
     button_choice = request.args.get('button_choice')
     if target_file:
         if button_choice == "Download":
-            jawa_logger().info(f"[{session.get('url')}] {session.get('username')} downloading file: {target_file}.")
+            logthis.info(f"[{session.get('url')}] {session.get('username')} downloading file: {target_file}.")
             return send_file(f'{files_dir}/{target_file}', as_attachment=True)
         elif button_choice == "Delete":
-            jawa_logger().info(f"[{session.get('url')}] {session.get('username')} deleting file: {target_file}.")
+            logthis.info(f"[{session.get('url')}] {session.get('username')} deleting file: {target_file}.")
             if os.path.exists(os.path.join(files_dir, target_file)):
                 os.remove(os.path.join(files_dir, target_file))
     if request.method == "POST":
-        jawa_logger().info(f"[{session.get('url')}] {session.get('username')} {request.path} {request.method}")
+        logthis.info(f"[{session.get('url')}] {session.get('username')} {request.path} {request.method}")
         upload_files_list = request.files.getlist('upload')
         for each_upload in upload_files_list:
             if ' ' in each_upload.filename:
                 each_upload.filename = each_upload.filename.replace(" ", "-")
-            jawa_logger().info(f"[{session.get('url')}] {session.get('username')} uploaded {each_upload.filename}.")
+            logthis.info(f"[{session.get('url')}] {session.get('username')} uploaded {each_upload.filename}.")
             each_upload.save(os.path.join(files_dir, secure_filename(each_upload.filename)))
-    jawa_logger().info(f"[{session.get('url')}] {session.get('username')} {request.path} {request.method}")
+    logthis.info(f"[{session.get('url')}] {session.get('username')} {request.path} {request.method}")
     file_list = os.listdir(files_dir)
     for file in file_list:
         if file[0] == '.':

--- a/views/resource_view.py
+++ b/views/resource_view.py
@@ -1,15 +1,14 @@
 import json
 from datetime import datetime
-from flask import current_app, session, redirect, url_for, render_template, Flask, Blueprint, send_file, request
+from flask import (Blueprint, escape, redirect, render_template,
+                   request, send_file, session, url_for)
 from bin import logger
 import os
 from werkzeug.utils import secure_filename
 
-from bin.load_home import load_home
 from bin.view_modifiers import response
 
-logthis = logger.setup_child_logger(__name__)
-logthis.info(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 log_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'jawa.log'))
 server_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
@@ -47,7 +46,6 @@ def files():
     for file in file_list:
         if file[0] == '.':
             file_list.remove(file)
-    print(file_list)
     files_list = []
     for each_file in file_list:
         mtime = os.path.getmtime(os.path.join(files_dir, each_file))

--- a/views/resource_view.py
+++ b/views/resource_view.py
@@ -1,7 +1,6 @@
 import json
 from datetime import datetime
 from flask import current_app, session, redirect, url_for, render_template, Flask, Blueprint, send_file, request
-from app import jawa_logger
 from bin import logger
 import os
 from werkzeug.utils import secure_filename

--- a/views/webhook_view.py
+++ b/views/webhook_view.py
@@ -13,7 +13,6 @@ from flask import (Flask, request, render_template,
 
 from bin.load_home import load_home
 from bin.view_modifiers import response
-from app import jawa_logger
 from bin import logger
 
 logthis = logger.setup_child_logger(__name__)

--- a/views/webhook_view.py
+++ b/views/webhook_view.py
@@ -1,22 +1,14 @@
-import os
-import json
-import glob
-import time
 from collections import defaultdict
-from time import sleep
+from flask import (Blueprint, redirect, request, session, url_for)
+import json
+import os
 import requests
-import re
-from werkzeug.utils import secure_filename
-from flask import (Flask, request, render_template,
-                   session, redirect, url_for, escape,
-                   send_from_directory, Blueprint, abort)
+import time
 
-from bin.load_home import load_home
-from bin.view_modifiers import response
 from bin import logger
+from bin.view_modifiers import response
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', __name__)
 
 blueprint = Blueprint('webhooks', __name__, template_folder='templates')
 
@@ -70,8 +62,6 @@ def delete_webhook():
                 with open(webhooks_file, 'w') as fout:
                     json.dump(webhook_json, fout, indent=4)
         return redirect(url_for('webhooks.webhooks'))
-
-    print(target_webhook, tag[0])
     return {'username': session.get('username'), 'target_webhook': target_webhook, 'tag': tag[0]}
 
 
@@ -94,6 +84,5 @@ def webhooks():
             jamf_pro_webhooks_list.append(each_webhook)
         elif tag == 'okta':
             okta_webhooks_list.append(each_webhook)
-    print(okta_webhooks_list)
     return {'username': session.get('username'), 'custom_list': custom_webhooks_list,
             'jamf_list': jamf_pro_webhooks_list, 'okta_list': okta_webhooks_list, 'url': session.get('url')}

--- a/views/webhook_view.py
+++ b/views/webhook_view.py
@@ -14,6 +14,10 @@ from flask import (Flask, request, render_template,
 from bin.load_home import load_home
 from bin.view_modifiers import response
 from app import jawa_logger
+from bin import logger
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
 
 blueprint = Blueprint('webhooks', __name__, template_folder='templates')
 
@@ -37,7 +41,7 @@ def delete_webhook():
     tag = [each_webhook['tag'] for each_webhook in webhook_json if each_webhook['name'] == target_webhook]
 
     if request.method == 'POST':
-        jawa_logger().info(f"Deleting {tag} webhook: {target_webhook}")
+        logthis.info(f"Deleting {tag} webhook: {target_webhook}")
         for each_webhook in webhook_json:
             if each_webhook['name'] == target_webhook:
                 script_file = each_webhook['script']

--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -1,5 +1,4 @@
-import flask
-from flask import request
+from flask import Blueprint, request
 import json
 import os
 import subprocess
@@ -7,14 +6,13 @@ import subprocess
 from bin import okta_verification
 from bin import logger
 
-logthis = logger.setup_child_logger(__name__)
-logthis.debug(f'this got logged by {__name__} child')
+logthis = logger.setup_child_logger('jawa', 'webhook_receiver')
 
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
 jp_webhooks_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'webhooks.json'))
 scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 
-blueprint = flask.Blueprint('jawa_receiver', __name__, template_folder='templates')
+blueprint = Blueprint('jawa_receiver', __name__, template_folder='templates')
 
 
 def validate_webhook(webhook_data, webhook_name, webhook_user, webhook_pass):
@@ -42,7 +40,6 @@ def run_script(webhook_data, webhook_name):
 
 
 def script_results(webhook_data, each_webhook):
-    print(webhook_data)
     webhook_data = json.dumps(webhook_data)
     proc = subprocess.Popen([each_webhook['script'], f"{webhook_data}"], stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)

--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -44,7 +44,9 @@ def script_results(webhook_data, each_webhook):
     proc = subprocess.Popen([each_webhook['script'], f"{webhook_data}"], stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     output = proc.stdout.read()
-    logthis.info(output.decode())
+    for each_line in output.decode().split('\n'):
+        if each_line:
+            logthis.info(f"{each_webhook.get('name')} - {each_line}")
     return output
 
 

--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -44,19 +44,19 @@ def script_results(webhook_data, each_webhook):
     proc = subprocess.Popen([each_webhook['script'], f"{webhook_data}"], stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     output = proc.stdout.read()
-    jawa_logger().info(output.decode())
+    logthis.info(output.decode())
     return output
 
 
 @blueprint.route('/hooks/<webhook_name>', methods=['POST', 'GET'])
 def webhook_handler(webhook_name):
-    jawa_logger().info(f"Incoming request at /hooks/{webhook_name} ...")
+    logthis.info(f"Incoming request at /hooks/{webhook_name} ...")
     webhook_data = request.get_json()
     if request.headers.get('x-okta-verification-challenge'):
-        jawa_logger().info("This is an Okta verification challenge...")
+        logthis.info("This is an Okta verification challenge...")
         return okta_verification.verify_new_webhook(request.headers.get('x-okta-verification-challenge'))
     if request.method != 'POST':
-        jawa_logger().info(f"Invalid request, {request.method} for /hooks/{webhook_name}.")
+        logthis.info(f"Invalid request, {request.method} for /hooks/{webhook_name}.")
         return "405 - Method not allowed. These aren't the droids you're looking for. You can go about your business. " \
                "Move along.", 405
     webhook_user = "null"
@@ -67,9 +67,9 @@ def webhook_handler(webhook_name):
         webhook_pass = auth.get("password")
 
     if validate_webhook(webhook_data, webhook_name, webhook_user, webhook_pass):
-        jawa_logger().info(f"Validated authentication for /hooks/{webhook_name}, running script...")
+        logthis.info(f"Validated authentication for /hooks/{webhook_name}, running script...")
         output = run_script(webhook_data, webhook_name)
         return {"webhook": f"{webhook_name}", "result": f"{output}"}, 202
     else:
-        jawa_logger().info(f"401 - Incorrect authentication provided for /hooks/{webhook_name}.")
+        logthis.info(f"401 - Incorrect authentication provided for /hooks/{webhook_name}.")
         return f"Unauthorized - incorrect authentication provided for /hooks/{webhook_name}.", 401

--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -4,8 +4,11 @@ import json
 import os
 import subprocess
 
-from app import jawa_logger
 from bin import okta_verification
+from bin import logger
+
+logthis = logger.setup_child_logger(__name__)
+logthis.debug(f'this got logged by {__name__} child')
 
 server_json_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'server.json'))
 jp_webhooks_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'webhooks.json'))


### PR DESCRIPTION
Lock in logging changes. Logger init function and child spawner are now in bin/logger.py 

Adding a child logger to nay py file in the project requires 3 lines of code:
```
from bin import logger
logthis = logger.setup_child_logger(__name__)
logthis.debug(f'this got logged by {__name__} child')
```

Then logging statements are the same syntax everywhere: `logthis.info("Message to be logged.")`

The app.py 'main' logger is defined with hard coded name of `'app'` because `(__name__)` produced unwanted results.

child log statements reflect the hierarchy and filename they came from, so troubleshooting and is simplified.
example log entries:

> ```
> 2022-05-16 11:22:37,533 - jawa.views.log_view - INFO - this got logged by views.log_view child
> 2022-05-16 11:22:37,536 - jawa.views.resource_view - INFO - this got logged by views.resource_view child
> 2022-05-16 11:22:37,539 - jawa.views.custom_webhook - DEBUG - this got logged by views.custom_webhook child
> 2022-05-16 11:22:37,541 - jawa.views.webhook_view - DEBUG - this got logged by views.webhook_view child
> ```