### PR TITLE
bugfix for custom webhook responses

### DIFF
--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -86,8 +86,7 @@ def custom_output_options(webhook_name):
             webhook_tag = each_webhook.get('tag')
             send_output = each_webhook.get('output')
             return webhook_tag, send_output
-        else:
-            return None, None
+    return None, None
 
 
 @blueprint.route('/hooks/<webhook_name>', methods=['POST', 'GET'])


### PR DESCRIPTION
Fixing an error where the option for receiving custom webhook script output as part of the response body would sometimes not be honored for some custom webhooks.