### PR TITLE
Feature: templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,10 @@ dmypy.json
 
 # ruff
 .ruff_cache
+
+# JAWA runtime data
+data/server.json
+data/credentials.json
+data/cron.json
+data/webhooks.json
+resources/files/

--- a/data/workflows/scripts/device_naming.py
+++ b/data/workflows/scripts/device_naming.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Auto-rename mobile devices by asset tag on enrollment.
+
+Webhook event: MobileDeviceEnrolled
+API privileges: Read Mobile Devices, Send Mobile Device Set Device Name Command
+"""
+
+import json
+import logging
+import requests
+import sys
+import time
+
+token_cache = {"access_token": None, "expires_in": 0, "timestamp": 0}
+
+
+class Config:
+    def __init__(self):
+        self.server_url = "https://example.jamfcloud.com"  # Your Jamf Pro URL
+        self.token_url = f"{self.server_url}/api/oauth/token"
+        self.client_id = "your_client_id"
+        self.client_secret = "your_client_secret"
+        self.scope = ""  # e.g., api-role:5
+
+
+def get_oauth_token():
+    global token_cache
+    current_time = time.time()
+    config = Config()
+    if (
+        token_cache["access_token"]
+        and (current_time - token_cache["timestamp"])
+        < token_cache["expires_in"]
+    ):
+        return token_cache["access_token"]
+    data = {
+        "client_id": config.client_id,
+        "grant_type": "client_credentials",
+        "client_secret": config.client_secret,
+    }
+    if config.scope:
+        data["scope"] = config.scope
+    response = requests.post(
+        config.token_url,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data=data,
+    )
+    response_data = response.json()
+    token_cache = {
+        "access_token": response_data["access_token"],
+        "expires_in": response_data["expires_in"],
+        "timestamp": current_time,
+    }
+    return token_cache["access_token"]
+
+
+def api_get(endpoint):
+    config = Config()
+    token = get_oauth_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    resp = requests.get(
+        f"{config.server_url}/JSSResource/{endpoint}", headers=headers
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_post(endpoint):
+    config = Config()
+    token = get_oauth_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    resp = requests.post(
+        f"{config.server_url}/JSSResource/{endpoint}", headers=headers
+    )
+    resp.raise_for_status()
+    return resp
+
+
+def main():
+    # 1. Parse webhook event
+    try:
+        event_data = json.loads(sys.argv[1])
+    except (json.JSONDecodeError, IndexError) as err:
+        print(f"Error parsing webhook JSON: {err}")
+        sys.exit(1)
+
+    event = event_data["event"]
+    jss_id = str(event["jssID"])
+    old_name = event.get("deviceName", "Unknown")
+    serial = event.get("serialNumber", "Unknown")
+    room = event.get("room", "")
+
+    # 2. Filter: skip bedside devices (those with room assignments)
+    if room:
+        print(f"Device has room assignment ({room}) - skipping rename.")
+        sys.exit(5)
+
+    # 3. Wait for device record to populate, then look up asset tag
+    time.sleep(30)
+    try:
+        device_record = api_get(f"mobiledevices/id/{jss_id}")
+        asset_tag = device_record["mobile_device"]["general"].get("asset_tag")
+    except Exception as err:
+        print(f"Could not GET device record for ID {jss_id}: {err}")
+        sys.exit(2)
+
+    if not asset_tag:
+        print(f"No asset tag for ID {jss_id}. Exiting.")
+        sys.exit(3)
+
+    # 4. Send DeviceName command
+    try:
+        api_post(
+            f"mobiledevicecommands/command/DeviceName/{asset_tag}/id/{jss_id}"
+        )
+        print(
+            f"Renamed {old_name} -> {asset_tag} (SN: {serial}, ID: {jss_id})"
+        )
+    except Exception as err:
+        print(f"Failed to rename device ID {jss_id}: {err}")
+        sys.exit(4)
+
+    # 5. Send blank push to speed up command delivery
+    try:
+        api_post(f"mobiledevicecommands/command/BlankPush/id/{jss_id}")
+    except Exception:
+        pass  # Non-critical
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/ea_update.py
+++ b/data/workflows/scripts/ea_update.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Update mobile device extension attribute from webhook event.
+
+Handles both Jamf Pro standard webhook events and custom JSON posts.
+"""
+
+import json
+import requests
+import sys
+import time
+
+token_cache = {"access_token": None, "expires_in": 0, "timestamp": 0}
+
+
+class Config:
+    def __init__(self):
+        self.server_url = "https://example.jamfcloud.com"
+        self.token_url = f"{self.server_url}/api/oauth/token"
+        self.client_id = "your_client_id"
+        self.client_secret = "your_client_secret"
+        self.scope = ""
+
+
+def get_oauth_token():
+    global token_cache
+    config = Config()
+    current_time = time.time()
+    if (
+        token_cache["access_token"]
+        and (current_time - token_cache["timestamp"])
+        < token_cache["expires_in"]
+    ):
+        return token_cache["access_token"]
+    response = requests.post(
+        config.token_url,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "client_id": config.client_id,
+            "grant_type": "client_credentials",
+            "client_secret": config.client_secret,
+        },
+    )
+    rd = response.json()
+    token_cache = {
+        "access_token": rd["access_token"],
+        "expires_in": rd["expires_in"],
+        "timestamp": current_time,
+    }
+    return token_cache["access_token"]
+
+
+def build_ea_xml(ea_name, value):
+    return (
+        f"<mobile_device><extension_attributes><extension_attribute>"
+        f"<name>{ea_name}</name><value>{value}</value>"
+        f"</extension_attribute></extension_attributes></mobile_device>"
+    )
+
+
+def main():
+    config = Config()
+    event_data = json.loads(sys.argv[1])
+
+    # Support both custom and standard webhook formats
+    if "DeviceID" in event_data:
+        # Custom webhook format
+        device_id = event_data["DeviceID"]
+        ea_name = event_data["EaName"]
+        value = event_data["Value"]
+    else:
+        # Standard Jamf Pro webhook
+        device_id = event_data["event"]["jssID"]
+        ea_name = "Last Webhook Action"
+        value = event_data["webhook"]["webhookEvent"]
+
+    # Build XML and send PUT
+    xml_data = build_ea_xml(ea_name, value)
+    token = get_oauth_token()
+    resp = requests.put(
+        f"{config.server_url}/JSSResource/mobiledevices/id/{device_id}",
+        headers={
+            "Content-Type": "application/xml",
+            "Authorization": f"Bearer {token}",
+        },
+        data=xml_data,
+    )
+    resp.raise_for_status()
+    print(f"Updated EA '{ea_name}' = '{value}' for device {device_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/enrollment_pipeline.py
+++ b/data/workflows/scripts/enrollment_pipeline.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Multi-step enrollment pipeline.
+
+Supports multiple webhook trigger events:
+  - MobileDeviceEnrolled (single device)
+  - ComputerAdded (single device)
+  - SmartGroupMobileDeviceMembershipChange (batch of devices)
+"""
+
+import csv, json, logging, requests, sys, time
+
+# ... (Config, OAuth, perform_api_call from foundations) ...
+
+CSV_FILE = "/usr/local/JAWA/resources/files/DeviceAssignments.csv"
+
+
+def extract_device_ids(event_data):
+    """Extract device ID(s) from any supported webhook event type."""
+    event = event_data.get("event", {})
+    webhook_event = event_data.get("webhook", {}).get("webhookEvent", "")
+
+    # Smart group events provide a list of added device IDs
+    if "SmartGroup" in webhook_event:
+        ids = event.get("groupAddedDevicesIds", [])
+        return [int(i) for i in ids] if ids else []
+
+    # Enrollment and add events provide a single device ID
+    jss_id = event.get("jssID")
+    if jss_id:
+        return [int(jss_id)]
+
+    return []
+
+
+def main():
+    # Stage 1-2: Parse event
+    event_data = json.loads(sys.argv[1])
+    id_list = extract_device_ids(event_data)
+    if not id_list:
+        sys.exit(12)
+
+    for jss_id in id_list:
+        # Stage 3: Get device serial, match to CSV
+        time.sleep(30)
+        device = api_get(f"api/v2/mobile-devices/{jss_id}/detail")
+        serial = device.get("serialNumber")
+        model = device.get("model", "")
+
+        # Apple TV fork
+        if "appletv" in model.lower():
+            handle_apple_tv(jss_id, serial)
+            continue
+
+        assignment = lookup_csv(serial, CSV_FILE)
+        if not assignment:
+            print(f"{serial} not in spreadsheet.")
+            continue
+
+        # Stage 4: Update device record
+        update_record(jss_id, assignment)
+
+        # Stage 5: Queue commands
+        set_device_name(jss_id, assignment["name"])
+
+        # Stage 6: Poll for DeviceConfigured
+        completed = poll_command(jss_id, "DeviceConfigured")
+
+        if completed:
+            print(f"ID {jss_id} ({serial}) completed setup.")
+        else:
+            print(f"ID {jss_id} ({serial}) failed - erasing.")
+            send_erase(jss_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/event_tracker_sqlite.py
+++ b/data/workflows/scripts/event_tracker_sqlite.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Track webhook events in a SQLite database with cooldown logic.
+
+Webhook event: ComputerCheckIn, MobileDeviceCheckIn
+API privileges: None (logging only)
+"""
+
+import datetime
+import json
+import sqlite3
+import sys
+
+DB_PATH = "placeholder_value"  # Path to SQLite database file
+COOLDOWN_HOURS = 12  # Hours between recording repeat check-ins
+
+
+def create_check_in_db(db_path):
+    """Create SQLite database for check-in tracking."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""CREATE TABLE IF NOT EXISTS check_in_stats (
+        jps_id INTEGER NOT NULL PRIMARY KEY,
+        serial_number TEXT NOT NULL,
+        device_name TEXT,
+        last_check_in TEXT NOT NULL,
+        total_check_ins INTEGER NOT NULL DEFAULT 1
+    )""")
+    conn.commit()
+    return conn
+
+
+def record_check_in(
+    conn, jss_id, serial, device_name, event_time, cooldown_hours=12
+):
+    """Record a device check-in with cooldown logic.
+
+    Returns True if the check-in was recorded (outside cooldown).
+    Returns False if within cooldown window.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT last_check_in, total_check_ins FROM check_in_stats WHERE jps_id=?",
+        (jss_id,),
+    )
+    row = cur.fetchone()
+
+    if not row:
+        conn.execute(
+            "INSERT INTO check_in_stats "
+            "(jps_id, serial_number, device_name, last_check_in, total_check_ins) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (jss_id, serial, device_name, event_time),
+        )
+        conn.commit()
+        return True
+
+    last_time = datetime.datetime.strptime(row[0], "%Y-%m-%d %H:%M:%S")
+    current_time = datetime.datetime.strptime(event_time, "%Y-%m-%d %H:%M:%S")
+    delta = current_time - last_time
+    total = row[1]
+
+    if delta.total_seconds() >= (cooldown_hours * 3600):
+        conn.execute(
+            "UPDATE check_in_stats SET last_check_in=?, total_check_ins=?, "
+            "device_name=? WHERE jps_id=?",
+            (event_time, total + 1, device_name, jss_id),
+        )
+        conn.commit()
+        print(
+            f"  {device_name}: check-in recorded (total: {total + 1}, delta: {delta})"
+        )
+        return True
+    else:
+        conn.execute(
+            "UPDATE check_in_stats SET total_check_ins=? WHERE jps_id=?",
+            (total + 1, jss_id),
+        )
+        conn.commit()
+        print(
+            f"  {device_name}: within cooldown ({delta} < {cooldown_hours}h)"
+        )
+        return False
+
+
+def main():
+    # 1. Parse webhook event
+    try:
+        event_data = json.loads(sys.argv[1])
+    except (json.JSONDecodeError, IndexError) as err:
+        print(f"Error parsing webhook JSON: {err}")
+        sys.exit(1)
+
+    event = event_data.get("event", {})
+    jss_id = event.get("jssID") or event.get("computer", {}).get("jssID")
+    serial = event.get("serialNumber", "Unknown")
+    device_name = event.get("deviceName") or event.get("computer", {}).get(
+        "deviceName", "Unknown"
+    )
+
+    if not jss_id:
+        print("No device ID found in event data.")
+        sys.exit(2)
+
+    event_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    # 2. Open database and record
+    conn = create_check_in_db(DB_PATH)
+    recorded = record_check_in(
+        conn, jss_id, serial, device_name, event_time, COOLDOWN_HOURS
+    )
+    conn.close()
+
+    if recorded:
+        print(f"Check-in recorded for {device_name} (ID: {jss_id})")
+    else:
+        print(f"Check-in within cooldown for {device_name} (ID: {jss_id})")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/return_to_service.py
+++ b/data/workflows/scripts/return_to_service.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Return to Service automation via smart group webhook.
+
+Webhook event: SmartGroupMobileDeviceMembershipChange
+When devices enter the target smart group, this script:
+1. Sets an EA to track RtS status
+2. Looks up the device managementId
+3. Sends ERASE_DEVICE with returnToService enabled
+
+"""
+
+import base64
+import json
+import logging
+import requests
+import sys
+import time
+
+token_cache = {"access_token": None, "expires_in": 0, "timestamp": 0}
+
+
+class Config:
+    def __init__(self):
+        self.server_url = "https://example.jamfcloud.com"
+        self.token_url = f"{self.server_url}/api/oauth/token"
+        self.client_id = "your_client_id"
+        self.client_secret = "your_client_secret"
+        self.scope = ""
+
+
+# WiFi profile XML (base64 will be encoded at runtime)
+WIFI_PAYLOAD = b"""<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1"><dict>
+  <key>PayloadUUID</key><string>RTS-UNIQUE-UUID</string>
+  <key>PayloadType</key><string>Configuration</string>
+  <key>PayloadIdentifier</key><string>RTS-UNIQUE-UUID</string>
+  <key>PayloadContent</key><array><dict>
+    <key>PayloadType</key><string>com.apple.wifi.managed</string>
+    <key>SSID_STR</key><string>Your-WiFi-SSID</string>
+    <key>AutoJoin</key><true/>
+    <key>CaptiveBypass</key><true/>
+  </dict></array>
+</dict></plist>"""
+
+EA_NAME = "RtS Status"
+
+
+def get_oauth_token():
+    global token_cache
+    current_time = time.time()
+    config = Config()
+    if (
+        token_cache["access_token"]
+        and (current_time - token_cache["timestamp"])
+        < token_cache["expires_in"]
+    ):
+        return token_cache["access_token"]
+    response = requests.post(
+        config.token_url,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "client_id": config.client_id,
+            "grant_type": "client_credentials",
+            "client_secret": config.client_secret,
+            "scope": config.scope,
+        },
+    )
+    rd = response.json()
+    token_cache = {
+        "access_token": rd["access_token"],
+        "expires_in": rd["expires_in"],
+        "timestamp": current_time,
+    }
+    return token_cache["access_token"]
+
+
+def get_headers(content_type="json"):
+    token = get_oauth_token()
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+        if content_type == "json"
+        else "application/xml",
+    }
+
+
+def build_ea_xml(ea_name, value):
+    return (
+        f"<mobile_device><extension_attributes><extension_attribute>"
+        f"<name>{ea_name}</name><value>{value}</value>"
+        f"</extension_attribute></extension_attributes></mobile_device>"
+    )
+
+
+def main():
+    config = Config()
+    # 1. Parse event
+    event_data = json.loads(sys.argv[1])
+    id_list = event_data["event"]["groupAddedDevicesIds"]
+    if not id_list:
+        print("No devices entered the group.")
+        sys.exit(12)
+
+    # 2. Encode WiFi payload
+    wifi_b64 = base64.b64encode(WIFI_PAYLOAD).decode("ascii")
+
+    # 3. Process each device
+    for jss_id in id_list:
+        # Set EA to prevent re-triggering
+        ea_xml = build_ea_xml(EA_NAME, "Enrolled")
+        headers = get_headers("xml")
+        requests.put(
+            f"{config.server_url}/JSSResource/mobiledevices/id/{jss_id}",
+            headers=headers,
+            data=ea_xml,
+        )
+
+        # Look up managementId
+        headers = get_headers()
+        resp = requests.get(
+            f"{config.server_url}/api/v2/mobile-devices/{jss_id}",
+            headers=headers,
+        )
+        mgmt_id = resp.json().get("managementId")
+
+        # Send erase with RtS
+        erase_json = {
+            "clientData": [{"managementId": mgmt_id}],
+            "commandData": {
+                "commandType": "ERASE_DEVICE",
+                "preserveDataPlan": True,
+                "disallowProximitySetup": False,
+                "returnToService": {
+                    "enabled": True,
+                    "wifiProfileData": wifi_b64,
+                },
+            },
+        }
+        resp = requests.post(
+            f"{config.server_url}/api/v2/mdm/commands",
+            headers=get_headers(),
+            json=erase_json,
+        )
+        resp.raise_for_status()
+        print(f"Device {jss_id}: RtS command sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/smart_group_appletv.py
+++ b/data/workflows/scripts/smart_group_appletv.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Restart Apple TVs that join a smart group.
+
+Webhook event: SmartGroupMobileDeviceMembershipChange
+"""
+
+import json
+import requests
+import sys
+import time
+
+# ... (Config, OAuth, perform_api_call from foundations) ...
+
+
+def main():
+    event_data = json.loads(sys.argv[1])
+    id_list = event_data["event"]["groupAddedDevicesIds"]
+
+    if not id_list:
+        print("No devices entered the group.")
+        sys.exit(12)
+
+    for jss_id in id_list:
+        print(f"Restarting device ID {jss_id}...")
+        time.sleep(200)  # Wait for Apple TV to be responsive
+        perform_api_call(
+            f"mobiledevicecommands/command/RestartDevice/id/{jss_id}",
+            method="POST",
+        )
+        time.sleep(10)
+        perform_api_call(
+            f"mobiledevicecommands/command/UpdateInventory/id/{jss_id}",
+            method="POST",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/smart_group_slack.py
+++ b/data/workflows/scripts/smart_group_slack.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Send Slack notification on smart group membership change.
+
+Webhook event: SmartGroupComputerMembershipChange
+"""
+
+import json
+import requests
+import sys
+from datetime import datetime
+
+SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+
+
+def main():
+    event_data = json.loads(sys.argv[1])
+    event = event_data["event"]
+
+    id_list = event.get("groupAddedDevicesIds", [])
+    if not id_list:
+        print("No devices entered the group.")
+        sys.exit(12)
+
+    group_name = event.get("name", "Unknown Group")
+    _device_names = event.get("groupAddedDevices", [])
+
+    slack_data = {
+        "attachments": [
+            {
+                "color": "#056ae6",
+                "title": f"Smart Group Update: {group_name}",
+                "text": f"{len(id_list)} device(s) added to {group_name}",
+                "footer": "JAWA Webhook Automation",
+                "ts": datetime.timestamp(datetime.now()),
+            }
+        ]
+    }
+
+    resp = requests.post(
+        SLACK_WEBHOOK_URL,
+        data=json.dumps(slack_data),
+        headers={"Content-Type": "application/json"},
+    )
+    print(f"Slack notification: {resp.status_code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/scripts/teams_notification.py
+++ b/data/workflows/scripts/teams_notification.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Send Microsoft Teams notifications for Jamf Pro webhook events.
+
+Webhook event: Any Jamf Pro webhook event
+API privileges: None (outbound notification only)
+"""
+
+import json
+import requests
+import sys
+
+TEAMS_WEBHOOK_URL = "placeholder_value"  # Teams incoming webhook URL
+
+
+def send_teams_notification(webhook_url, title, message, facts=None):
+    """Send a notification to Microsoft Teams via incoming webhook.
+
+    Uses Adaptive Card format for rich messages.
+
+    Args:
+        webhook_url: Teams incoming webhook URL
+        title: Card title
+        message: Card body text
+        facts: List of {"name": str, "value": str} dicts
+    """
+    body = [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": title,
+        },
+        {"type": "TextBlock", "text": message, "wrap": True},
+    ]
+
+    if facts:
+        body.append({"type": "FactSet", "facts": facts})
+
+    card = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "contentUrl": None,
+                "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": body,
+                },
+            }
+        ],
+    }
+
+    response = requests.post(
+        webhook_url,
+        data=json.dumps(card),
+        headers={"Content-Type": "application/json"},
+    )
+    return response.status_code == 200
+
+
+def main():
+    # 1. Parse webhook event
+    try:
+        event_data = json.loads(sys.argv[1])
+    except (json.JSONDecodeError, IndexError) as err:
+        print(f"Error parsing webhook JSON: {err}")
+        sys.exit(1)
+
+    webhook_name = event_data.get("webhook", {}).get(
+        "webhookEvent", "Unknown Event"
+    )
+    event = event_data.get("event", {})
+
+    # 2. Build notification details
+    device_name = event.get("deviceName") or event.get("computer", {}).get(
+        "deviceName", "Unknown"
+    )
+    serial = event.get("serialNumber") or event.get("computer", {}).get(
+        "serialNumber", "Unknown"
+    )
+    jss_id = event.get("jssID") or event.get("computer", {}).get(
+        "jssID", "Unknown"
+    )
+
+    title = f"Jamf Pro: {webhook_name}"
+    message = f"Event received for device **{device_name}**."
+
+    facts = [
+        {"name": "Event", "value": webhook_name},
+        {"name": "Device", "value": device_name},
+        {"name": "Serial", "value": str(serial)},
+        {"name": "JSS ID", "value": str(jss_id)},
+    ]
+
+    # 3. Send notification
+    success = send_teams_notification(TEAMS_WEBHOOK_URL, title, message, facts)
+
+    if success:
+        print(f"Teams notification sent for {webhook_name}: {device_name}")
+    else:
+        print(f"Failed to send Teams notification for {webhook_name}")
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/workflows/workflow_config.json
+++ b/data/workflows/workflow_config.json
@@ -1,0 +1,304 @@
+[
+    {
+        "slug": "device-naming",
+        "title": "Device Naming by Asset Tag",
+        "description": "Automatically rename mobile devices using their Inventory Preload asset tag when they enroll.",
+        "category": "provisioning",
+        "trigger_type": "webhook",
+        "trigger_event": "MobileDeviceEnrolled",
+        "script_file": "device_naming.py",
+        "notebook_slug": "device-naming",
+        "api_privileges": [
+            "Read Mobile Devices",
+            "Send Mobile Device Set Device Name Command"
+        ],
+        "config_params": [
+            {
+                "key": "server_url",
+                "label": "Jamf Pro URL",
+                "placeholder": "https://example.jamfcloud.com",
+                "type": "text"
+            },
+            {
+                "key": "client_id",
+                "label": "OAuth Client ID",
+                "placeholder": "your_client_id",
+                "type": "text"
+            },
+            {
+                "key": "client_secret",
+                "label": "OAuth Client Secret",
+                "placeholder": "your_client_secret",
+                "type": "password"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — device renamed"},
+            {"code": 1, "meaning": "Invalid webhook JSON"},
+            {"code": 2, "meaning": "Could not retrieve device record"},
+            {"code": 3, "meaning": "No asset tag found"},
+            {"code": 4, "meaning": "Rename command failed"},
+            {"code": 5, "meaning": "Device has room assignment (skipped)"}
+        ],
+        "tags": ["enrollment", "mobile", "naming", "asset-tag"],
+        "order": 1
+    },
+    {
+        "slug": "smart-group-slack",
+        "title": "Smart Group Slack Notification",
+        "description": "Send a Slack message when devices are added to a smart group.",
+        "category": "observability",
+        "trigger_type": "webhook",
+        "trigger_event": "SmartGroupComputerMembershipChange",
+        "script_file": "smart_group_slack.py",
+        "notebook_slug": "smart-group-actions",
+        "api_privileges": [],
+        "config_params": [
+            {
+                "key": "SLACK_WEBHOOK_URL",
+                "label": "Slack Webhook URL",
+                "placeholder": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+                "type": "text"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — notification sent"},
+            {"code": 12, "meaning": "No devices entered the group"}
+        ],
+        "tags": ["smart-group", "slack", "notification"],
+        "order": 2
+    },
+    {
+        "slug": "smart-group-appletv",
+        "title": "Apple TV Restart on Smart Group",
+        "description": "Automatically restart Apple TV devices and update inventory when they join a smart group.",
+        "category": "provisioning",
+        "trigger_type": "webhook",
+        "trigger_event": "SmartGroupMobileDeviceMembershipChange",
+        "script_file": "smart_group_appletv.py",
+        "notebook_slug": "smart-group-actions",
+        "api_privileges": [
+            "Send Mobile Device Restart Device Command",
+            "Send Mobile Device Update Inventory Command"
+        ],
+        "config_params": [
+            {
+                "key": "server_url",
+                "label": "Jamf Pro URL",
+                "placeholder": "https://example.jamfcloud.com",
+                "type": "text"
+            },
+            {
+                "key": "client_id",
+                "label": "OAuth Client ID",
+                "placeholder": "your_client_id",
+                "type": "text"
+            },
+            {
+                "key": "client_secret",
+                "label": "OAuth Client Secret",
+                "placeholder": "your_client_secret",
+                "type": "password"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — devices restarted"},
+            {"code": 12, "meaning": "No devices entered the group"}
+        ],
+        "tags": ["smart-group", "apple-tv", "restart", "mobile"],
+        "order": 3
+    },
+    {
+        "slug": "return-to-service",
+        "title": "Return to Service",
+        "description": "Erase and re-enroll mobile devices with WiFi profile when they enter a smart group, enabling zero-touch device recycling.",
+        "category": "provisioning",
+        "trigger_type": "webhook",
+        "trigger_event": "SmartGroupMobileDeviceMembershipChange",
+        "script_file": "return_to_service.py",
+        "notebook_slug": "return-to-service",
+        "api_privileges": [
+            "Read Mobile Devices",
+            "Update Mobile Devices",
+            "Send Mobile Device Erase Device Command"
+        ],
+        "config_params": [
+            {
+                "key": "server_url",
+                "label": "Jamf Pro URL",
+                "placeholder": "https://example.jamfcloud.com",
+                "type": "text"
+            },
+            {
+                "key": "client_id",
+                "label": "OAuth Client ID",
+                "placeholder": "your_client_id",
+                "type": "text"
+            },
+            {
+                "key": "client_secret",
+                "label": "OAuth Client Secret",
+                "placeholder": "your_client_secret",
+                "type": "password"
+            },
+            {
+                "key": "wifi_ssid",
+                "label": "WiFi SSID",
+                "placeholder": "Your-WiFi-SSID",
+                "type": "text"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — erase with RtS sent"},
+            {"code": 12, "meaning": "No devices entered the group"}
+        ],
+        "tags": ["smart-group", "mobile", "erase", "return-to-service", "wipe"],
+        "order": 4
+    },
+    {
+        "slug": "enrollment-pipeline",
+        "title": "Enrollment Pipeline",
+        "description": "Multi-stage enrollment workflow that matches devices to a CSV assignment list, updates records, and provisions automatically.",
+        "category": "provisioning",
+        "trigger_type": "webhook",
+        "trigger_event": "MobileDeviceEnrolled / ComputerAdded",
+        "script_file": "enrollment_pipeline.py",
+        "notebook_slug": "enrollment-pipeline",
+        "api_privileges": [
+            "Read Mobile Devices",
+            "Update Mobile Devices",
+            "Send Mobile Device Set Device Name Command",
+            "Send Mobile Device Erase Device Command"
+        ],
+        "config_params": [
+            {
+                "key": "server_url",
+                "label": "Jamf Pro URL",
+                "placeholder": "https://example.jamfcloud.com",
+                "type": "text"
+            },
+            {
+                "key": "client_id",
+                "label": "OAuth Client ID",
+                "placeholder": "your_client_id",
+                "type": "text"
+            },
+            {
+                "key": "client_secret",
+                "label": "OAuth Client Secret",
+                "placeholder": "your_client_secret",
+                "type": "password"
+            },
+            {
+                "key": "CSV_FILE",
+                "label": "CSV Assignment File Path",
+                "placeholder": "/usr/local/JAWA/resources/files/DeviceAssignments.csv",
+                "type": "text"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — pipeline completed"},
+            {"code": 12, "meaning": "No devices entered the group"}
+        ],
+        "tags": ["enrollment", "mobile", "pipeline", "csv", "provisioning"],
+        "order": 5
+    },
+    {
+        "slug": "event-tracker-sqlite",
+        "title": "Event Tracker (SQLite)",
+        "description": "Log webhook check-in events to a SQLite database with configurable cooldown to prevent duplicate processing.",
+        "category": "observability",
+        "trigger_type": "webhook",
+        "trigger_event": "ComputerCheckIn",
+        "script_file": "event_tracker_sqlite.py",
+        "notebook_slug": "event-tracking",
+        "api_privileges": [],
+        "config_params": [
+            {
+                "key": "DB_PATH",
+                "label": "SQLite Database Path",
+                "placeholder": "placeholder_value",
+                "type": "text"
+            },
+            {
+                "key": "COOLDOWN_HOURS",
+                "label": "Cooldown Hours",
+                "placeholder": "12",
+                "type": "number"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — event recorded or within cooldown"},
+            {"code": 1, "meaning": "Invalid webhook JSON"},
+            {"code": 2, "meaning": "No device ID found in event"}
+        ],
+        "tags": ["check-in", "logging", "sqlite", "cooldown"],
+        "order": 6
+    },
+    {
+        "slug": "teams-notification",
+        "title": "Teams Notification",
+        "description": "Send Microsoft Teams Adaptive Card notifications for any Jamf Pro webhook event.",
+        "category": "observability",
+        "trigger_type": "webhook",
+        "trigger_event": "Any Event",
+        "script_file": "teams_notification.py",
+        "notebook_slug": "event-tracking",
+        "api_privileges": [],
+        "config_params": [
+            {
+                "key": "TEAMS_WEBHOOK_URL",
+                "label": "Teams Webhook URL",
+                "placeholder": "placeholder_value",
+                "type": "text"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — notification sent"},
+            {"code": 1, "meaning": "Invalid webhook JSON"},
+            {"code": 3, "meaning": "Failed to send notification"}
+        ],
+        "tags": ["teams", "notification", "adaptive-card"],
+        "order": 7
+    },
+    {
+        "slug": "ea-update",
+        "title": "Extension Attribute Update",
+        "description": "Update a mobile device extension attribute from webhook events, supporting both standard Jamf Pro and custom JSON formats.",
+        "category": "extensions",
+        "trigger_type": "webhook",
+        "trigger_event": "ComputerInventoryCompleted",
+        "script_file": "ea_update.py",
+        "notebook_slug": "extension-attributes",
+        "api_privileges": [
+            "Read Mobile Devices",
+            "Update Mobile Devices"
+        ],
+        "config_params": [
+            {
+                "key": "server_url",
+                "label": "Jamf Pro URL",
+                "placeholder": "https://example.jamfcloud.com",
+                "type": "text"
+            },
+            {
+                "key": "client_id",
+                "label": "OAuth Client ID",
+                "placeholder": "your_client_id",
+                "type": "text"
+            },
+            {
+                "key": "client_secret",
+                "label": "OAuth Client Secret",
+                "placeholder": "your_client_secret",
+                "type": "password"
+            }
+        ],
+        "exit_codes": [
+            {"code": 0, "meaning": "Success — EA updated"},
+            {"code": 1, "meaning": "Invalid webhook JSON"}
+        ],
+        "tags": ["extension-attribute", "mobile", "classic-api"],
+        "order": 8
+    }
+]

--- a/templates/workflows/catalog.html
+++ b/templates/workflows/catalog.html
@@ -1,0 +1,57 @@
+{% extends "shared/_layout.html" %}
+{% block title %}Templates - JAWA{% endblock %}
+{% block content %}
+<div class="hero-section">
+    <div class="container">
+        <h2>Template Catalog</h2>
+        <p>Pre-built automation templates for Jamf Pro webhooks.</p>
+        <div class="hero-cta">
+            <a href="/templates/import" class="btn btn-hero-primary">Import Template</a>
+            <a href="/webhooks" class="btn btn-hero-secondary">View Webhooks</a>
+        </div>
+    </div>
+</div>
+<div class="container" style="max-width: 1100px;">
+    <div class="text-center mb-4">
+        <button class="filter-btn active" onclick="filterWorkflows('all', this)">All</button>
+        <button class="filter-btn" onclick="filterWorkflows('provisioning', this)">Provisioning</button>
+        <button class="filter-btn" onclick="filterWorkflows('observability', this)">Observability</button>
+        <button class="filter-btn" onclick="filterWorkflows('extensions', this)">Extensions</button>
+    </div>
+
+    <div class="row g-3">
+        {% for wf in workflows %}
+        <div class="col-md-6 col-lg-4 workflow-item" data-category="{{ wf.category }}">
+            <a href="/templates/{{ wf.slug }}" style="text-decoration: none;">
+                <div class="workflow-card">
+                    <span class="badge badge-{{ wf.category }} mb-2">{{ wf.category }}</span>
+                    <h5 class="card-title">{{ wf.title }}</h5>
+                    <p class="card-text">{{ wf.description }}</p>
+                    <div style="font-size: 0.75rem; color: var(--color-text-muted);">
+                        {{ wf.trigger_event }}
+                    </div>
+                </div>
+            </a>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}
+
+{% block additional_js %}
+<script>
+function filterWorkflows(category, btn) {
+    var items = document.querySelectorAll('.workflow-item');
+    items.forEach(function(item) {
+        if (category === 'all' || item.dataset.category === category) {
+            item.style.display = '';
+        } else {
+            item.style.display = 'none';
+        }
+    });
+    var btns = document.querySelectorAll('.filter-btn');
+    btns.forEach(function(b) { b.classList.remove('active'); });
+    btn.classList.add('active');
+}
+</script>
+{% endblock %}

--- a/templates/workflows/enable.html
+++ b/templates/workflows/enable.html
@@ -1,0 +1,64 @@
+{% extends "shared/_layout.html" %}
+{% block title %}Enable {{ workflow.title }} - JAWA{% endblock %}
+{% block content %}
+<div class="container" style="max-width: 750px; padding-top: 2rem;">
+    <div class="mb-3">
+        <a href="/templates/{{ workflow.slug }}" style="color: var(--color-primary); font-size: 0.88rem;">&larr; Back to {{ workflow.title }}</a>
+    </div>
+
+    <h2 style="font-size: 1.6rem; text-align: left; letter-spacing: -0.5px; margin-top: 0.5rem;">Enable Template</h2>
+    <p style="color: var(--color-text-secondary); font-size: 0.92rem;">
+        Configure and install <strong>{{ workflow.title }}</strong> as a webhook automation.
+    </p>
+
+    <div class="form-section mt-4">
+        <form method="post" action="/templates/{{ workflow.slug }}/enable">
+            <div class="mb-3">
+                <label for="webhook-name" class="form-label" style="font-weight: 500;">Webhook Name</label>
+                <input type="text" name="webhook_name" id="webhook-name" class="form-control"
+                       value="{{ workflow.title }}" required>
+            </div>
+
+            {% if credentials %}
+            <div class="mb-4">
+                <label for="credential-set" class="form-label" style="font-weight: 500;">Credential Set</label>
+                <select name="credential_set" id="credential-set" class="form-control">
+                    <option value="">-- None (configure manually below) --</option>
+                    {% for cred in credentials %}
+                    <option value="{{ loop.index0 }}">{{ cred.name }} ({{ cred.server_url }})</option>
+                    {% endfor %}
+                </select>
+                <div class="form-text" style="color: var(--color-text-muted); font-size: 0.82rem;">
+                    Select a saved credential set to auto-fill server URL, client ID, and client secret.
+                </div>
+            </div>
+            {% else %}
+            <div class="mb-4" style="font-size: 0.85rem; color: var(--color-text-muted);">
+                No saved credential sets. <a href="/setup/credentials">Add one in Setup</a> or configure values below.
+            </div>
+            {% endif %}
+
+            {% if workflow.config_params %}
+            <h6 style="font-weight: 600; font-size: 0.92rem; margin-top: 1.5rem; margin-bottom: 0.75rem;">Template Configuration</h6>
+            {% for param in workflow.config_params %}
+            <div class="mb-3">
+                <label for="param-{{ param.key }}" class="form-label" style="font-weight: 500; font-size: 0.88rem;">{{ param.label }}</label>
+                <input type="{{ param.type or 'text' }}" name="{{ param.key }}" id="param-{{ param.key }}"
+                       class="form-control" placeholder="{{ param.placeholder }}">
+            </div>
+            {% endfor %}
+            {% endif %}
+
+            <div class="d-flex justify-content-center mt-4">
+                <button type="submit" class="btn btn-jawa">Enable Template</button>
+            </div>
+        </form>
+    </div>
+
+    {% if workflow.trigger_event %}
+    <div class="mt-3 mb-5" style="font-size: 0.82rem; color: var(--color-text-muted); text-align: center;">
+        This template listens for: <strong>{{ workflow.trigger_event }}</strong>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/workflows/import.html
+++ b/templates/workflows/import.html
@@ -1,0 +1,27 @@
+{% extends "shared/_layout.html" %}
+{% block title %}Import Template - JAWA{% endblock %}
+{% block content %}
+<div class="container" style="max-width: 700px; padding-top: 2rem;">
+    <div class="mb-3">
+        <a href="/templates" style="color: var(--color-primary); font-size: 0.88rem;">&larr; Back to Catalog</a>
+    </div>
+
+    <h2 style="font-size: 1.8rem; letter-spacing: -1px;">Import Template</h2>
+    <p style="color: var(--color-text-secondary);">
+        Upload a <code>.jawa.json</code> package to install a new template.
+    </p>
+
+    <div class="form-section mt-4">
+        <form method="post" enctype="multipart/form-data">
+            <div class="mb-3">
+                <label for="package" class="form-label" style="font-weight: 500;">Template Package</label>
+                <input type="file" name="package" id="package" accept=".json" class="form-control">
+                <div class="form-text" style="color: var(--color-text-muted); font-size: 0.82rem;">
+                    Select a <code>.jawa.json</code> file exported from the template documentation site.
+                </div>
+            </div>
+            <button type="submit" class="btn btn-jawa mt-2">Import</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/views/template_view.py
+++ b/views/template_view.py
@@ -1,0 +1,462 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Copyright (c) 2026 Jamf.  All rights reserved.
+#
+#       Redistribution and use in source and binary forms, with or without
+#       modification, are permitted provided that the following conditions are met:
+#               * Redistributions of source code must retain the above copyright
+#                 notice, this list of conditions and the following disclaimer.
+#               * Redistributions in binary form must reproduce the above copyright
+#                 notice, this list of conditions and the following disclaimer in the
+#                 documentation and/or other materials provided with the distribution.
+#               * Neither the name of the Jamf nor the names of its contributors may be
+#                 used to endorse or promote products derived from this software without
+#                 specific prior written permission.
+#
+#       THIS SOFTWARE IS PROVIDED BY JAMF SOFTWARE, LLC "AS IS" AND ANY
+#       EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#       DISCLAIMED. IN NO EVENT SHALL JAMF SOFTWARE, LLC BE LIABLE FOR ANY
+#       DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#       LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#       ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#       SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+import json
+import os
+from typing import Any, Dict, List, Union
+
+from flask import (
+    Blueprint,
+    Response,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    session,
+    url_for,
+)
+from markupsafe import escape
+
+from bin import logger
+from bin.view_modifiers import response
+
+blueprint = Blueprint(
+    "template_view",
+    __name__,
+    template_folder="../templates",
+)
+
+logthis = logger.setup_child_logger("jawa", "template_view")
+
+ERROR_TITLE = "Session Timed Out"
+ERROR_MSG_SIGN_IN = "Please sign in again"
+ERROR_INVALID_PKG = "Invalid Package"
+LOGOUT_ENDPOINT = "home_view.logout"
+CATALOG_ENDPOINT = "template_view.catalog"
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW_CONFIG = os.path.join(
+    BASE_DIR, "data", "workflows", "workflow_config.json"
+)
+TEMPLATE_SCRIPTS_DIR = os.path.join(BASE_DIR, "data", "workflows", "scripts")
+SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts")
+WEBHOOKS_FILE = os.path.join(BASE_DIR, "data", "webhooks.json")
+CREDENTIALS_FILE = os.path.join(BASE_DIR, "data", "credentials.json")
+
+
+def _load_config() -> list:
+    """Load the workflow configuration file."""
+    try:
+        with open(WORKFLOW_CONFIG, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        logthis.warning("Could not load workflow_config.json")
+        return []
+
+
+def _get_workflow_by_slug(slug: str) -> Union[Dict[str, Any], None]:
+    """Look up a workflow by its URL slug."""
+    workflows = _load_config()
+    for wf in workflows:
+        if wf.get("slug") == slug:
+            return wf
+    return None
+
+
+def _load_credentials() -> List[Dict[str, Any]]:
+    """Load saved credential sets."""
+    if not os.path.isfile(CREDENTIALS_FILE):
+        return []
+    try:
+        with open(CREDENTIALS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+
+
+def _install_package(package: dict) -> None:
+    """Install a .jawa.json workflow package into JAWA."""
+    script = package["script"]
+    script_path = os.path.join(SCRIPTS_DIR, script["filename"])
+    with open(script_path, "w", encoding="utf-8") as f:
+        f.write(script["content"])
+    os.chmod(script_path, 0o755)
+
+    _register_webhook(
+        {
+            "name": package["name"],
+            "event": package["trigger"]["event"],
+            "script": script["filename"],
+            "enabled": True,
+        }
+    )
+
+    logthis.info(
+        f"Installed workflow package: {package['name']} "
+        f"(script: {script['filename']})"
+    )
+
+
+def _load_webhooks() -> list:
+    """Load the current webhooks list from disk."""
+    if not os.path.isfile(WEBHOOKS_FILE):
+        return []
+    try:
+        with open(WEBHOOKS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+
+
+def _register_webhook(entry: dict) -> None:
+    """Append a webhook entry and save to disk."""
+    webhooks = _load_webhooks()
+    webhooks.append(entry)
+    with open(WEBHOOKS_FILE, "w", encoding="utf-8") as f:
+        json.dump(webhooks, f, indent=2)
+
+
+def _apply_credentials(
+    script_content: str,
+    workflow: dict,
+    credential_index: str,
+    credentials: list,
+) -> str:
+    """Substitute credential placeholders in script content."""
+    if not credential_index or not credentials:
+        return script_content
+    try:
+        cred = credentials[int(credential_index)]
+    except (ValueError, IndexError):
+        return script_content
+
+    cred_keys = ("server_url", "client_id", "client_secret")
+    for param in workflow.get("config_params", []):
+        key = param.get("key", "")
+        if key in cred_keys and cred.get(key):
+            script_content = script_content.replace(
+                param["placeholder"], cred[key]
+            )
+    return script_content
+
+
+def _apply_form_params(script_content: str, workflow: dict) -> str:
+    """Substitute remaining form-supplied placeholders."""
+    for param in workflow.get("config_params", []):
+        key = param.get("key", "")
+        form_value = request.form.get(key, "")
+        if form_value:
+            form_value = str(escape(form_value))
+            script_content = script_content.replace(
+                param["placeholder"], form_value
+            )
+    return script_content
+
+
+def _write_script(name: str, content: str) -> str:
+    """Write script content to a unique file and return the filename."""
+    safe_name = name.replace(" ", "_").replace("/", "_").lower()
+    dest_filename = f"{safe_name}.py"
+    dest_path = os.path.join(SCRIPTS_DIR, dest_filename)
+
+    counter = 1
+    while os.path.isfile(dest_path):
+        dest_filename = f"{safe_name}_{counter}.py"
+        dest_path = os.path.join(SCRIPTS_DIR, dest_filename)
+        counter += 1
+
+    with open(dest_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.chmod(dest_path, 0o755)
+    return dest_filename
+
+
+def _validate_package(package: dict) -> Union[str, None]:
+    """Validate a .jawa.json package. Returns error message or None."""
+    for field in ("name", "trigger", "script"):
+        if field not in package:
+            return f"Missing required field: {field}"
+
+    if (
+        "filename" not in package["script"]
+        or "content" not in package["script"]
+    ):
+        return "Script must have filename and content."
+
+    if "event" not in package["trigger"]:
+        return "Trigger must have an event field."
+
+    return None
+
+
+# ---- Backward-compat redirects from /workflows ----
+
+
+@blueprint.route("/workflows")
+def workflows_redirect() -> Response:
+    return redirect(url_for(CATALOG_ENDPOINT), code=301)
+
+
+@blueprint.route("/workflows/<path:rest>")
+def workflows_rest_redirect(rest: str) -> Response:
+    return redirect(f"/templates/{rest}", code=301)
+
+
+# ---- Template routes ----
+
+
+@blueprint.route("/templates")
+@response(template_file="workflows/catalog.html")
+def catalog() -> Union[Response, Dict[str, Any]]:
+    """Template catalog page showing all bundled templates."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+    workflows = _load_config()
+    workflows.sort(key=lambda w: w.get("order", 99))
+
+    categories: Dict[str, list] = {}
+    for wf in workflows:
+        cat = wf.get("category", "other")
+        categories.setdefault(cat, []).append(wf)
+
+    return {
+        "username": session.get("username"),
+        "workflows": workflows,
+        "categories": categories,
+    }
+
+
+@blueprint.route("/templates/<slug>")
+@response(template_file="workflows/detail.html")
+def detail(slug: str) -> Union[Response, Dict[str, Any]]:
+    """Template detail page with description and script preview."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+    slug = str(escape(slug))
+    workflow = _get_workflow_by_slug(slug)
+    if not workflow:
+        return redirect(url_for(CATALOG_ENDPOINT))
+
+    script_content = ""
+    script_path = os.path.join(TEMPLATE_SCRIPTS_DIR, workflow["script_file"])
+    if os.path.isfile(script_path):
+        with open(script_path, "r", encoding="utf-8") as f:
+            script_content = f.read()
+
+    credentials = _load_credentials()
+
+    return {
+        "username": session.get("username"),
+        "workflow": workflow,
+        "script_content": script_content,
+        "credentials": credentials,
+    }
+
+
+@blueprint.route("/templates/<slug>/script")
+def download_script(slug: str) -> Union[Response, str]:
+    """Download the template script file."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+    slug = str(escape(slug))
+    workflow = _get_workflow_by_slug(slug)
+    if not workflow:
+        return redirect(url_for(CATALOG_ENDPOINT))
+
+    script_path = os.path.join(TEMPLATE_SCRIPTS_DIR, workflow["script_file"])
+    if not os.path.isfile(script_path):
+        return redirect(
+            url_for(
+                "error",
+                error="Script not found",
+                error_message=f"Script {workflow['script_file']} not found.",
+            )
+        )
+
+    return send_file(
+        script_path,
+        as_attachment=True,
+        download_name=workflow["script_file"],
+    )
+
+
+@blueprint.route("/templates/<slug>/enable", methods=["GET", "POST"])
+def enable_template(slug: str) -> Union[Response, str]:
+    """Enable a template: configure and install as a webhook."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+
+    slug = str(escape(slug))
+    workflow = _get_workflow_by_slug(slug)
+    if not workflow:
+        return redirect(url_for(CATALOG_ENDPOINT))
+
+    credentials = _load_credentials()
+
+    if request.method == "GET":
+        return render_template(
+            "workflows/enable.html",
+            username=session.get("username"),
+            workflow=workflow,
+            credentials=credentials,
+        )
+
+    # POST: enable the template
+    webhook_name = str(
+        escape(request.form.get("webhook_name", workflow["title"]))
+    )
+
+    src_path = os.path.join(TEMPLATE_SCRIPTS_DIR, workflow["script_file"])
+    if not os.path.isfile(src_path):
+        return redirect(
+            url_for(
+                "error",
+                error="Script not found",
+                error_message=f"Script {workflow['script_file']} not found.",
+            )
+        )
+
+    with open(src_path, "r", encoding="utf-8") as f:
+        script_content = f.read()
+
+    script_content = _apply_credentials(
+        script_content,
+        workflow,
+        request.form.get("credential_set", ""),
+        credentials,
+    )
+    script_content = _apply_form_params(script_content, workflow)
+    dest_filename = _write_script(webhook_name, script_content)
+
+    _register_webhook(
+        {
+            "name": webhook_name,
+            "tag": "custom",
+            "url": session.get("url", ""),
+            "event": workflow.get("trigger_event", ""),
+            "script": dest_filename,
+            "description": workflow.get("description", ""),
+            "enabled": True,
+        }
+    )
+
+    logthis.info(
+        f"[{session.get('url')}] {session.get('username')} "
+        f"enabled template: {webhook_name} (script: {dest_filename})"
+    )
+
+    return redirect(
+        url_for(
+            "success",
+            success_msg=f"Enabled template: {webhook_name}",
+        )
+    )
+
+
+@blueprint.route("/templates/import", methods=["GET", "POST"])
+@response(template_file="workflows/import.html")
+def import_template() -> Union[Response, Dict[str, Any]]:
+    """Upload a .jawa.json package to install a new template."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+
+    if request.method != "POST":
+        return {"username": session.get("username")}
+
+    uploaded = request.files.get("package")
+    if not uploaded or not uploaded.filename.endswith(".jawa.json"):
+        return redirect(
+            url_for(
+                "error",
+                error="Invalid File",
+                error_message="Please upload a .jawa.json file.",
+            )
+        )
+
+    try:
+        package = json.load(uploaded)
+    except json.JSONDecodeError:
+        return redirect(
+            url_for(
+                "error",
+                error="Invalid JSON",
+                error_message="The uploaded file is not valid JSON.",
+            )
+        )
+
+    validation_error = _validate_package(package)
+    if validation_error:
+        return redirect(
+            url_for(
+                "error",
+                error=ERROR_INVALID_PKG,
+                error_message=validation_error,
+            )
+        )
+
+    _install_package(package)
+    logthis.info(
+        f"[{session.get('url')}] {session.get('username')} "
+        f"imported template: {package['name']}"
+    )
+    return redirect(
+        url_for(
+            "success",
+            success_msg=f"Installed template: {package['name']}",
+        )
+    )


### PR DESCRIPTION
This pull request introduces a suite of new Python scripts for automating Jamf Pro workflows, focusing on device management, notifications, and event tracking. The scripts cover device enrollment, naming, smart group actions, and outbound notifications to Slack and Microsoft Teams, as well as event logging using SQLite. The most important changes are grouped below by theme.

**Device Management Automation:**

* Added `device_naming.py` to automate renaming of mobile devices based on asset tag during enrollment, with logic to skip bedside devices and ensure asset tag presence before sending the rename command.
* Added `enrollment_pipeline.py` to orchestrate a multi-step enrollment process for mobile devices, including CSV-based assignment lookup, device record updates, command queuing, and conditional erase for failed setups.
* Added `ea_update.py` to update mobile device extension attributes from webhook events, supporting both standard and custom JSON formats.
* Added `return_to_service.py` for automating "Return to Service" actions via smart group webhooks, setting extension attributes, sending erase commands with WiFi payload, and handling device management IDs.
* Added `smart_group_appletv.py` to restart Apple TVs that join a smart group, including inventory update commands after restart.

**Event Tracking and Notification:**

* Added `event_tracker_sqlite.py` to log device check-in events in a SQLite database, implementing cooldown logic to avoid duplicate records within a set time window.
* Added `smart_group_slack.py` to send Slack notifications when devices are added to a smart group, formatting messages with device count and group name.
* Added `teams_notification.py` to send Microsoft Teams notifications for any Jamf Pro webhook event, using Adaptive Cards for rich message formatting and including device/event details.