### PR TITLE
feat: add credential management and search functionality

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,93 @@
+"use strict";
+
+function escapeHtml(text) {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function escapeAttr(text) {
+    return text
+        .replaceAll("&", "&amp;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+}
+
+const BADGE_STYLES = {
+    webhook: "background:var(--color-navbar);color:#fff;",
+    cron: "background:var(--color-accent-light);color:#fff;",
+    template: "background:var(--color-primary);color:#fff;",
+    page: "background:#6c757d;color:#fff;",
+};
+
+function buildBadge(resultType) {
+    const style = BADGE_STYLES[resultType];
+    if (!style) return "";
+    const label = resultType.charAt(0).toUpperCase() + resultType.slice(1);
+    return ' <span style="font-size:0.65rem;' + style + 'padding:1px 5px;border-radius:3px;">' + label + "</span>";
+}
+
+function buildResultHtml(results, query) {
+    let html = "";
+    results.slice(0, 8).forEach(function (result) {
+        html += '<a class="search-result-item" href="' + escapeAttr(result.url) + '">';
+        html += '<div class="search-result-title">' + escapeHtml(result.title) + buildBadge(result.result_type) + "</div>";
+        if (result.description) {
+            html += '<div style="font-size:0.78rem;color:#666;padding-top:2px;">' + escapeHtml(result.description).substring(0, 80) + "</div>";
+        }
+        html += "</a>";
+    });
+
+    html += '<a class="search-result-item" href="/search?q=' + encodeURIComponent(query) + '" style="text-align:center;color:var(--color-primary);font-weight:600;">View all results</a>';
+    return html;
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+    const searchInput = document.getElementById("navbar-search");
+    const dropdown = document.getElementById("search-dropdown");
+    if (!searchInput || !dropdown) return;
+
+    let debounceTimer = null;
+
+    searchInput.addEventListener("input", function () {
+        const query = searchInput.value.trim();
+        clearTimeout(debounceTimer);
+
+        if (query.length < 2) {
+            dropdown.style.display = "none";
+            dropdown.innerHTML = "";
+            return;
+        }
+
+        debounceTimer = setTimeout(function () {
+            fetch("/api/search?q=" + encodeURIComponent(query))
+                .then(function (resp) { return resp.json(); })
+                .then(function (data) {
+                    if (!data.results || data.results.length === 0) {
+                        dropdown.innerHTML = '<div class="search-result-item" style="color:#999;">No results found</div>';
+                    } else {
+                        dropdown.innerHTML = buildResultHtml(data.results, query);
+                    }
+                    dropdown.style.display = "block";
+                });
+        }, 300);
+    });
+
+    document.addEventListener("click", function (e) {
+        if (!searchInput.contains(e.target) && !dropdown.contains(e.target)) {
+            dropdown.style.display = "none";
+        }
+    });
+
+    searchInput.addEventListener("keydown", function (e) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            const query = searchInput.value.trim();
+            if (query.length >= 2) {
+                globalThis.location.href = "/search?q=" + encodeURIComponent(query);
+            }
+        }
+    });
+});

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,0 +1,49 @@
+{% extends "shared/_layout.html" %}
+{% block title %}Search - JAWA{% endblock %}
+{% block content %}
+<div class="hero-section">
+    <div class="container">
+        <h2>Search Results{% if query %} for "{{ query }}"{% endif %}</h2>
+        <p>Search webhooks, cron jobs, templates, and pages.</p>
+    </div>
+</div>
+<div class="container" style="max-width: 900px;">
+
+    <form action="/search" method="get" class="mb-4">
+        <div class="d-flex gap-2">
+            <input type="text" name="q" value="{{ query }}" class="form-control" placeholder="Search webhooks, cron, templates, pages..." autofocus>
+            <button type="submit" class="btn btn-jawa">Search</button>
+        </div>
+    </form>
+
+    {% if results %}
+        <p style="color: var(--color-text-muted); font-size: 0.88rem;">{{ results|length }} result{{ 's' if results|length != 1 }} found</p>
+        <div class="list-group">
+            {% for result in results %}
+            <a href="{{ result.url }}" class="list-group-item list-group-item-action" style="border-radius: var(--radius-md); margin-bottom: 0.5rem; border: 1px solid var(--color-border);">
+                <div class="d-flex align-items-center gap-2">
+                    <h6 class="mb-1" style="font-weight: 600;">{{ result.title }}</h6>
+                    {% if result.result_type == 'webhook' %}
+                        <span class="badge" style="background: var(--color-navbar); font-size: 0.65rem;">Webhook</span>
+                    {% elif result.result_type == 'cron' %}
+                        <span class="badge" style="background: var(--color-accent-light); font-size: 0.65rem;">Cron</span>
+                    {% elif result.result_type == 'template' %}
+                        <span class="badge" style="background: var(--color-primary); font-size: 0.65rem;">Template</span>
+                    {% elif result.result_type == 'page' %}
+                        <span class="badge" style="background: #6c757d; font-size: 0.65rem;">Page</span>
+                    {% endif %}
+                </div>
+                {% if result.description %}
+                    <p class="mb-0" style="font-size: 0.85rem; color: var(--color-text-secondary);">{{ result.description }}</p>
+                {% endif %}
+            </a>
+            {% endfor %}
+        </div>
+    {% elif query %}
+        <div class="form-section text-center" style="max-width: 500px; margin: 2rem auto;">
+            <p style="color: var(--color-text-muted);">No results found for "{{ query }}".</p>
+            <p style="color: var(--color-text-muted); font-size: 0.85rem;">Try different keywords or check your spelling.</p>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/setup/credentials.html
+++ b/templates/setup/credentials.html
@@ -1,0 +1,79 @@
+{% extends "shared/_layout.html" %}
+{% block title %}Credentials - JAWA{% endblock %}
+{% block content %}
+<div class="hero-section">
+    <div class="container">
+        <h2>API Credentials</h2>
+        <p>Manage credential sets for use with templates.</p>
+        <div class="hero-cta">
+            <a href="/setup" class="btn btn-hero-secondary">Setup</a>
+            <a href="/cleanup" class="btn btn-hero-secondary">Cleanup</a>
+            <a href="/branding" class="btn btn-hero-secondary">Branding</a>
+        </div>
+    </div>
+</div>
+<div class="container" style="max-width: 800px;">
+
+    {% if credentials %}
+    <div class="form-section mb-4">
+        <table class="hippocrates">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Server URL</th>
+                    <th>Client ID</th>
+                    <th>Secret</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for cred in credentials %}
+                <tr>
+                    <td>{{ cred.name }}</td>
+                    <td style="font-size: 0.82rem;">{{ cred.server_url }}</td>
+                    <td style="font-size: 0.82rem;">{{ cred.client_id }}</td>
+                    <td style="font-size: 0.82rem; color: var(--color-text-muted);">
+                        {{ '*' * 8 if cred.client_secret else '' }}
+                    </td>
+                    <td>
+                        <form method="post" action="/setup/credentials/delete/{{ loop.index0 }}" style="display:inline;">
+                            <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this credential set?');">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <div class="form-section text-center mb-4" style="max-width: 500px; margin: 0 auto;">
+        <p style="color: var(--color-text-muted);">No credential sets configured yet.</p>
+    </div>
+    {% endif %}
+
+    <div class="form-section" style="max-width: 550px; margin: 0 auto;">
+        <h5 class="text-center mb-3" style="font-size: 1rem; font-weight: 600;">Add Credential Set</h5>
+        <form method="post" action="/setup/credentials/add">
+            <div class="mb-3">
+                <label for="cred-name" class="form-label" style="font-weight: 500; font-size: 0.88rem;">Name</label>
+                <input type="text" name="name" id="cred-name" class="form-control" placeholder="e.g. Production" required>
+            </div>
+            <div class="mb-3">
+                <label for="cred-url" class="form-label" style="font-weight: 500; font-size: 0.88rem;">Jamf Pro URL</label>
+                <input type="url" name="server_url" id="cred-url" class="form-control" placeholder="https://example.jamfcloud.com" pattern="https?://.+" title="Use https://">
+            </div>
+            <div class="mb-3">
+                <label for="cred-client-id" class="form-label" style="font-weight: 500; font-size: 0.88rem;">Client ID</label>
+                <input type="text" name="client_id" id="cred-client-id" class="form-control" placeholder="OAuth Client ID">
+            </div>
+            <div class="mb-3">
+                <label for="cred-secret" class="form-label" style="font-weight: 500; font-size: 0.88rem;">Client Secret</label>
+                <input type="password" name="client_secret" id="cred-secret" class="form-control" placeholder="OAuth Client Secret">
+            </div>
+            <div class="d-flex justify-content-center">
+                <button type="submit" class="btn btn-jawa">Add Credential Set</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/views/credential_view.py
+++ b/views/credential_view.py
@@ -1,0 +1,165 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Copyright (c) 2026 Jamf.  All rights reserved.
+#
+#       Redistribution and use in source and binary forms, with or without
+#       modification, are permitted provided that the following conditions are met:
+#               * Redistributions of source code must retain the above copyright
+#                 notice, this list of conditions and the following disclaimer.
+#               * Redistributions in binary form must reproduce the above copyright
+#                 notice, this list of conditions and the following disclaimer in the
+#                 documentation and/or other materials provided with the distribution.
+#               * Neither the name of the Jamf nor the names of its contributors may be
+#                 used to endorse or promote products derived from this software without
+#                 specific prior written permission.
+#
+#       THIS SOFTWARE IS PROVIDED BY JAMF SOFTWARE, LLC "AS IS" AND ANY
+#       EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#       DISCLAIMED. IN NO EVENT SHALL JAMF SOFTWARE, LLC BE LIABLE FOR ANY
+#       DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#       LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#       ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#       SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+import json
+import os
+from typing import Any, Dict, List, Union
+
+from flask import (
+    Blueprint,
+    Response,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from markupsafe import escape
+
+from bin import logger
+
+blueprint = Blueprint(
+    "credential_view",
+    __name__,
+    template_folder="../templates",
+)
+
+logthis = logger.setup_child_logger("jawa", "credential_view")
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CREDENTIALS_FILE = os.path.join(BASE_DIR, "data", "credentials.json")
+
+ERROR_TITLE = "Session Timed Out"
+ERROR_MSG_SIGN_IN = "Please sign in again"
+LOGOUT_ENDPOINT = "home_view.logout"
+
+
+def _load_credentials() -> List[Dict[str, Any]]:
+    """Load saved credential sets."""
+    if not os.path.isfile(CREDENTIALS_FILE):
+        return []
+    try:
+        with open(CREDENTIALS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+
+
+def _save_credentials(credentials: List[Dict[str, Any]]) -> None:
+    """Save credential sets to file."""
+    with open(CREDENTIALS_FILE, "w", encoding="utf-8") as f:
+        json.dump(credentials, f, indent=2)
+
+
+@blueprint.route("/setup/credentials", methods=["GET"])
+def credentials_page() -> Union[Response, str]:
+    """Credential management page."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+
+    credentials = _load_credentials()
+    return render_template(
+        "setup/credentials.html",
+        username=session.get("username"),
+        credentials=credentials,
+    )
+
+
+@blueprint.route("/setup/credentials/add", methods=["POST"])
+def add_credential() -> Response:
+    """Add a new credential set."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+
+    name = str(escape(request.form.get("name", "").strip()))
+    server_url = str(escape(request.form.get("server_url", "").strip()))
+    client_id = str(escape(request.form.get("client_id", "").strip()))
+    client_secret = request.form.get("client_secret", "").strip()
+
+    if not name:
+        return redirect(
+            url_for(
+                "error",
+                error="Invalid Input",
+                error_message="Credential name is required.",
+            )
+        )
+
+    credentials = _load_credentials()
+    credentials.append(
+        {
+            "name": name,
+            "server_url": server_url,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+    )
+    _save_credentials(credentials)
+
+    logthis.info(
+        f"[{session.get('url')}] {session.get('username')} "
+        f"added credential set: {name}"
+    )
+
+    return redirect(url_for("credential_view.credentials_page"))
+
+
+@blueprint.route("/setup/credentials/delete/<int:index>", methods=["POST"])
+def delete_credential(index: int) -> Response:
+    """Delete a credential set by index."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                LOGOUT_ENDPOINT,
+                error_title=ERROR_TITLE,
+                error_message=ERROR_MSG_SIGN_IN,
+            )
+        )
+
+    credentials = _load_credentials()
+    if 0 <= index < len(credentials):
+        removed = credentials.pop(index)
+        _save_credentials(credentials)
+        logthis.info(
+            f"[{session.get('url')}] {session.get('username')} "
+            f"deleted credential set: {removed.get('name')}"
+        )
+
+    return redirect(url_for("credential_view.credentials_page"))

--- a/views/search_view.py
+++ b/views/search_view.py
@@ -1,0 +1,286 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Copyright (c) 2026 Jamf.  All rights reserved.
+#
+#       Redistribution and use in source and binary forms, with or without
+#       modification, are permitted provided that the following conditions are met:
+#               * Redistributions of source code must retain the above copyright
+#                 notice, this list of conditions and the following disclaimer.
+#               * Redistributions in binary form must reproduce the above copyright
+#                 notice, this list of conditions and the following disclaimer in the
+#                 documentation and/or other materials provided with the distribution.
+#               * Neither the name of the Jamf nor the names of its contributors may be
+#                 used to endorse or promote products derived from this software without
+#                 specific prior written permission.
+#
+#       THIS SOFTWARE IS PROVIDED BY JAMF SOFTWARE, LLC "AS IS" AND ANY
+#       EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#       DISCLAIMED. IN NO EVENT SHALL JAMF SOFTWARE, LLC BE LIABLE FOR ANY
+#       DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#       LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#       ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#       SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+import json
+import os
+from typing import Any, Dict, List, Union
+
+from flask import (
+    Blueprint,
+    Response,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from markupsafe import escape
+
+from bin import logger
+
+blueprint = Blueprint(
+    "search_view",
+    __name__,
+    template_folder="../templates",
+)
+
+logthis = logger.setup_child_logger("jawa", "search_view")
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WEBHOOKS_FILE = os.path.join(BASE_DIR, "data", "webhooks.json")
+CRON_FILE = os.path.join(BASE_DIR, "data", "cron.json")
+WORKFLOW_CONFIG = os.path.join(
+    BASE_DIR, "data", "workflows", "workflow_config.json"
+)
+
+NAVIGABLE_PAGES: List[Dict[str, str]] = [
+    {
+        "title": "Dashboard",
+        "url": "/dashboard",
+        "description": "Main dashboard",
+    },
+    {"title": "Webhooks", "url": "/webhooks", "description": "All webhooks"},
+    {
+        "title": "Jamf Pro Webhooks",
+        "url": "/webhooks/jamf",
+        "description": "Jamf Pro webhook management",
+    },
+    {
+        "title": "Okta Webhooks",
+        "url": "/webhooks/okta",
+        "description": "Okta webhook management",
+    },
+    {
+        "title": "Custom Webhooks",
+        "url": "/webhooks/custom",
+        "description": "Custom webhook management",
+    },
+    {
+        "title": "Templates",
+        "url": "/templates",
+        "description": "Pre-built automation templates",
+    },
+    {
+        "title": "Cron Jobs",
+        "url": "/cron",
+        "description": "Timed automations",
+    },
+    {
+        "title": "Log",
+        "url": "/log/home.html",
+        "description": "Application log viewer",
+    },
+    {
+        "title": "Files",
+        "url": "/resources/files",
+        "description": "Uploaded files",
+    },
+    {"title": "Setup", "url": "/setup", "description": "Server configuration"},
+    {
+        "title": "Branding",
+        "url": "/branding",
+        "description": "App name and icon customization",
+    },
+    {
+        "title": "Cleanup",
+        "url": "/cleanup",
+        "description": "Remove old script files",
+    },
+    {
+        "title": "Credentials",
+        "url": "/setup/credentials",
+        "description": "API credential management",
+    },
+]
+
+
+TAG_URL_MAP = {
+    "jamfpro": "/webhooks/jamf",
+    "okta": "/webhooks/okta",
+}
+
+
+def _load_json_file(filepath: str) -> list:
+    """Load a JSON list from a file, returning [] on error."""
+    if not os.path.isfile(filepath):
+        return []
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+
+
+def _index_pages() -> List[Dict[str, Any]]:
+    """Index navigable pages."""
+    return [
+        {
+            "title": page["title"],
+            "description": page.get("description", ""),
+            "url": page["url"],
+            "result_type": "page",
+            "searchable": (
+                f"{page['title']} {page.get('description', '')}".lower()
+            ),
+        }
+        for page in NAVIGABLE_PAGES
+    ]
+
+
+def _index_webhooks() -> List[Dict[str, Any]]:
+    """Index webhook entries."""
+    results: List[Dict[str, Any]] = []
+    for wh in _load_json_file(WEBHOOKS_FILE):
+        name = wh.get("name", "")
+        event = wh.get("event", wh.get("okta_event", ""))
+        desc = wh.get("description", "")
+        script = wh.get("script", "")
+        tag = wh.get("tag", "custom")
+        url = TAG_URL_MAP.get(tag, "/webhooks/custom")
+        results.append(
+            {
+                "title": name,
+                "description": f"{event} - {desc}" if desc else event,
+                "url": url,
+                "result_type": "webhook",
+                "searchable": f"{name} {event} {desc} {script}".lower(),
+            }
+        )
+    return results
+
+
+def _index_crons() -> List[Dict[str, Any]]:
+    """Index cron job entries."""
+    results: List[Dict[str, Any]] = []
+    for cron in _load_json_file(CRON_FILE):
+        name = cron.get("name", "")
+        freq = cron.get("frequency", "")
+        desc = cron.get("description", "")
+        script = cron.get("script", "")
+        results.append(
+            {
+                "title": name,
+                "description": f"{freq} - {desc}" if desc else freq,
+                "url": "/cron",
+                "result_type": "cron",
+                "searchable": f"{name} {freq} {desc} {script}".lower(),
+            }
+        )
+    return results
+
+
+def _index_templates() -> List[Dict[str, Any]]:
+    """Index template catalog entries."""
+    results: List[Dict[str, Any]] = []
+    for tmpl in _load_json_file(WORKFLOW_CONFIG):
+        title = tmpl.get("title", "")
+        desc = tmpl.get("description", "")
+        tags = " ".join(tmpl.get("tags", []))
+        event = tmpl.get("trigger_event", "")
+        slug = tmpl.get("slug", "")
+        results.append(
+            {
+                "title": title,
+                "description": desc,
+                "url": f"/templates/{slug}",
+                "result_type": "template",
+                "searchable": f"{title} {desc} {tags} {event}".lower(),
+            }
+        )
+    return results
+
+
+def _build_search_index() -> List[Dict[str, Any]]:
+    """Build a flat search index from all data sources."""
+    return (
+        _index_pages()
+        + _index_webhooks()
+        + _index_crons()
+        + _index_templates()
+    )
+
+
+def _search(query: str, limit: int = 20) -> List[Dict[str, str]]:
+    """Search the index for matching results."""
+    index = _build_search_index()
+    query_lower = query.lower()
+    terms = query_lower.split()
+
+    results: List[Dict[str, Any]] = []
+    for item in index:
+        searchable = item["searchable"]
+        if all(term in searchable for term in terms):
+            results.append(
+                {
+                    "title": item["title"],
+                    "description": item.get("description", ""),
+                    "url": item["url"],
+                    "result_type": item["result_type"],
+                }
+            )
+    return results[:limit]
+
+
+@blueprint.route("/api/search")
+def api_search() -> Union[Response, str]:
+    """JSON search endpoint for the navbar dropdown."""
+    if "username" not in session:
+        return jsonify({"results": []})
+
+    query = request.args.get("q", "").strip()
+    if len(query) < 2:
+        return jsonify({"results": []})
+
+    query = str(escape(query))
+    results = _search(query, limit=8)
+    return jsonify({"results": results})
+
+
+@blueprint.route("/search")
+def search_page() -> Union[Response, str]:
+    """Full search results page."""
+    if "username" not in session:
+        return redirect(
+            url_for(
+                "home_view.logout",
+                error_title="Session Timed Out",
+                error_message="Please sign in again",
+            )
+        )
+
+    query = request.args.get("q", "").strip()
+    query = str(escape(query))
+    results = _search(query, limit=50) if len(query) >= 2 else []
+
+    return render_template(
+        "search_results.html",
+        username=session.get("username"),
+        query=query,
+        results=results,
+    )


### PR DESCRIPTION
This pull request introduces two major features: a credential management system and a unified search capability across webhooks, cron jobs, templates, and pages. It adds backend views, frontend templates, and JavaScript for interactive search, significantly improving usability and administration.

Credential management:

* Added `views/credential_view.py` to provide routes for listing, adding, and deleting API credential sets, storing them in `data/credentials.json` and enforcing session authentication.
* Added `templates/setup/credentials.html` for a user-friendly interface to view, add, and delete credential sets, including secure display and input validation.

Search functionality:

* Added `views/search_view.py` implementing a search index across webhooks, cron jobs, templates, and navigable pages, with both JSON API (`/api/search`) for instant results and a full results page (`/search`).
* Added `templates/search_results.html` to display search results with badges and descriptions, supporting all indexed resource types.
* Added `static/js/search.js` for interactive navbar search with debounced input, dropdown results, and navigation to the full results page.