### PR TITLE
fix: bug-fix batch — receiver, resource delete, error pages, login UX (B2/B3/B5 + J6 follow-up)

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,8 +69,14 @@ def _resolve_session_timeout(config: dict) -> int:
 
 # Initiate Flask
 app = Flask(__name__)
+# Secure cookies require HTTPS. JAWA runs HTTPS behind nginx in
+# production, so Secure defaults on. A Secure cookie is dropped by the
+# browser over plain http, which breaks local `python3 app.py` runs
+# (login succeeds but the session cookie never returns -> login loop).
+# Set JAWA_INSECURE_COOKIES=1 for local http development only.
+_secure_cookies = os.environ.get("JAWA_INSECURE_COOKIES") != "1"
 app.config.update(
-    SESSION_COOKIE_SECURE=True,
+    SESSION_COOKIE_SECURE=_secure_cookies,
     SESSION_COOKIE_HTTPONLY=True,
     SESSION_COOKIE_SAMESITE="Lax",
 )

--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ from flask import (
 )
 from markupsafe import escape
 from waitress import serve
-from typing import Any, Dict, Union
+from typing import Any, Dict, Tuple, Union
 
 from bin import logger
 from bin.context_processors import inject_common_vars, register_static_cache_bust
@@ -472,6 +472,56 @@ def page_not_found(e) -> Union[Response, str]:
         f"An invalid path ({request.path}) was provided and no user is logged in.  Returning login page."
     )
     return load_home()
+
+
+@app.errorhandler(500)
+def internal_error(e) -> Union[Response, Tuple[str, int]]:
+    logthis.exception(
+        f"500 at {request.path} for "
+        f"{session.get('username', 'anonymous')}"
+    )
+    if "username" in session:
+        return (
+            render_template(
+                "error.html",
+                username=session.get("username"),
+                error="Something went wrong",
+                error_message="An unexpected error occurred. "
+                "The details have been logged.",
+            ),
+            500,
+        )
+    return load_home(), 500
+
+
+@app.errorhandler(403)
+def forbidden(e) -> Union[Response, Tuple[str, int]]:
+    if "username" in session:
+        return (
+            render_template(
+                "error.html",
+                username=session.get("username"),
+                error="Forbidden",
+                error_message="You do not have access to that resource.",
+            ),
+            403,
+        )
+    return load_home(), 403
+
+
+@app.errorhandler(405)
+def method_not_allowed(e) -> Union[Response, Tuple[str, int]]:
+    if "username" in session:
+        return (
+            render_template(
+                "error.html",
+                username=session.get("username"),
+                error="Method not allowed",
+                error_message="That action isn't allowed here.",
+            ),
+            405,
+        )
+    return load_home(), 405
 
 
 if __name__ == "__main__":

--- a/templates/home.html
+++ b/templates/home.html
@@ -58,10 +58,11 @@
         {% else %}
             <label for="login-url" class="visually-hidden">Jamf Pro URL</label>
             <input id="login-url" name="url" type="url" placeholder="Jamf Pro URL" pattern="https?://.+" title="Use https://" required
+                   value="{{ prev_url if prev_url }}"
                    class="form-control text-center" autofocus>
         {% endif %}
         <label for="login-username" class="visually-hidden">Username</label>
-        <input id="login-username" name="username" type="text" placeholder="Username" required class="form-control text-center" autofocus>
+        <input id="login-username" name="username" type="text" placeholder="Username" required value="{{ prev_username if prev_username }}" class="form-control text-center" autofocus>
         <label for="login-password" class="visually-hidden">Password</label>
         <input id="login-password" name="password" type="password" placeholder="Password" required class="form-control text-center">
 

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,31 @@
+"""Branded 500/405 error handlers (J7/B5)."""
+
+import app as jawa_app
+
+
+def test_500_renders_branded_page_no_traceback(jawa_env):
+    # The app is a long-lived singleton that has already served requests,
+    # so a fresh route cannot be registered mid-suite. Invoke the handler
+    # directly inside a request context instead: the assertions that matter
+    # are the 500 status and that the internal detail is never leaked.
+    exc = RuntimeError("kaboom-secret-detail")
+    with jawa_app.app.test_request_context("/_boom_test"):
+        from flask import session
+
+        session["username"] = "pytest-admin"
+        session["url"] = "https://jamf.example.test"
+        body, status = jawa_app.internal_error(exc)
+
+    assert status == 500
+    # Branded page rendered; internal exception detail not leaked.
+    assert "error-card" in body
+    assert "kaboom-secret-detail" not in body
+
+
+def test_405_renders_branded_page(logged_in_client):
+    # /dashboard is GET-only; POST should 405 via the branded handler.
+    resp = logged_in_client.post("/dashboard")
+    assert resp.status_code == 405
+    body = resp.data.decode()
+    assert "error-card" in body
+    assert "Method not allowed" in body

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -42,3 +42,46 @@ def test_login_error_surfaces_when_no_jps_configured(client, jawa_env):
     # logout() HTML-escapes the message before rendering, so the
     # apostrophe surfaces as its entity in the login page body.
     assert "Passwords can&#39;t be blank" in body
+
+
+def test_failed_login_retains_username_and_url(client, jawa_env, fake_jamf):
+    # The plain url input only renders when no jps_url is locked in
+    # server.json, which is the scenario where retaining the typed URL
+    # matters. The default fixture locks a jps_url, so clear it here.
+    import json
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+    resp = client.post(
+        "/login",
+        data={
+            "url": "https://jamf.example.test",
+            "username": "hojo",
+            "password": "",  # blank password -> auth failure
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert 'value="hojo"' in body
+    assert 'value="https://jamf.example.test"' in body
+    # Password must never be echoed back into the page.
+    assert 'type="password"' in body  # field still present
+    # (no password value assertion -- it must not be retained at all)
+
+
+def test_failed_login_does_not_reflect_script_injection(
+    client, jawa_env, fake_jamf
+):
+    import json
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+    resp = client.post(
+        "/login",
+        data={
+            "url": "https://jamf.example.test",
+            "username": "<script>alert(1)</script>",
+            "password": "",
+        },
+        follow_redirects=True,
+    )
+    body = resp.data.decode()
+    # Autoescaped -- the raw tag must not appear unescaped in the body.
+    assert "<script>alert(1)</script>" not in body

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -68,6 +68,17 @@ def test_failed_login_retains_username_and_url(client, jawa_env, fake_jamf):
     # (no password value assertion -- it must not be retained at all)
 
 
+def test_prev_url_not_reflected_without_error(client, jawa_env):
+    # A bare GET with prev_url but NO failed-login error must NOT
+    # pre-fill the JPS URL field (phishing pre-fill prevention).
+    import json
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+    resp = client.get("/?prev_url=https://evil-jamf.example&prev_username=admin")
+    body = resp.data.decode()
+    assert "https://evil-jamf.example" not in body
+    assert 'value="admin"' not in body
+
+
 def test_failed_login_does_not_reflect_script_injection(
     client, jawa_env, fake_jamf
 ):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -26,3 +26,19 @@ def test_logout_clears_session(logged_in_client):
 def test_anonymous_home_renders(client):
     resp = client.get("/")
     assert resp.status_code == 200
+
+
+def test_login_error_surfaces_when_no_jps_configured(client, jawa_env):
+    # server.json with no jps_url is the branch that dropped errors.
+    import json
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+    resp = client.get(
+        "/logout?error_title=Authentication+error"
+        "&error_message=Passwords+can%27t+be+blank"
+    )
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "Authentication error" in body
+    # logout() HTML-escapes the message before rendering, so the
+    # apostrophe surfaces as its entity in the login page body.
+    assert "Passwords can&#39;t be blank" in body

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -79,6 +79,22 @@ def test_prev_url_not_reflected_without_error(client, jawa_env):
     assert 'value="admin"' not in body
 
 
+def test_prev_url_not_reflected_via_logout_error_param(client, jawa_env):
+    # The prior gate keyed on error_title, which is attacker-suppliable
+    # via /logout query params. Confirm a crafted /logout link canNOT
+    # pre-fill the JPS URL / username (no session flash present).
+    import json
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+    resp = client.get(
+        "/logout?error_title=x&prev_url=https://evil-jamf.example"
+        "&prev_username=admin",
+        follow_redirects=True,
+    )
+    body = resp.data.decode()
+    assert "https://evil-jamf.example" not in body
+    assert 'value="admin"' not in body
+
+
 def test_failed_login_does_not_reflect_script_injection(
     client, jawa_env, fake_jamf
 ):

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -178,22 +178,12 @@ def test_null_json_body_is_a_teapot(client, jawa_env, fake_popen):
     assert fake_popen.calls == []
 
 
-@pytest.mark.xfail(
-    reason="J4/B2: form-payload fallback is unguarded; a bodyless "
-    "POST raises instead of returning 4xx",
-    strict=True,
-)
 def test_bodyless_post_returns_4xx(client, jawa_env, fake_popen):
     resp = client.post("/hooks/testhook")
     assert 400 <= resp.status_code < 500
     assert fake_popen.calls == []
 
 
-@pytest.mark.xfail(
-    reason="J4/B2: method check happens after body parsing, so a "
-    "bare GET crashes in the form fallback instead of 405ing",
-    strict=True,
-)
 def test_get_method_returns_405(client, jawa_env, fake_popen):
     resp = client.get("/hooks/testhook")
     assert resp.status_code == 405

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,14 @@
+"""Resource file deletion edge cases (J5/B3)."""
+
+
+def test_delete_with_no_file_selected_does_not_500(logged_in_client, jawa_env):
+    # POST with no target_file query param — must not raise NameError/500.
+    resp = logged_in_client.post("/resources/delete.html")
+    assert resp.status_code < 500
+
+
+def test_delete_nonexistent_file_does_not_500(logged_in_client, jawa_env):
+    resp = logged_in_client.post(
+        "/resources/delete.html?target_file=nope.txt"
+    )
+    assert resp.status_code < 500

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -24,9 +24,30 @@ def test_resolve_rejects_off_ladder_values():
 
 
 def test_cookie_flags_are_hardened():
+    # Default (env var unset): Secure on, as in production.
     assert jawa_app.app.config["SESSION_COOKIE_SECURE"] is True
     assert jawa_app.app.config["SESSION_COOKIE_HTTPONLY"] is True
     assert jawa_app.app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+
+
+def test_insecure_cookies_opt_out_expression(monkeypatch):
+    # The Secure flag is computed at import as
+    # (JAWA_INSECURE_COOKIES != "1"). Verify that logic directly rather
+    # than reloading the app module (reload corrupts the shared app
+    # singleton other tests depend on). Secure-by-default; only the
+    # explicit "1" opt-out disables it.
+    def secure_for(env_value):
+        if env_value is None:
+            monkeypatch.delenv("JAWA_INSECURE_COOKIES", raising=False)
+        else:
+            monkeypatch.setenv("JAWA_INSECURE_COOKIES", env_value)
+        import os
+
+        return os.environ.get("JAWA_INSECURE_COOKIES") != "1"
+
+    assert secure_for(None) is True        # unset -> secure (prod)
+    assert secure_for("0") is True         # anything but "1" -> secure
+    assert secure_for("1") is False        # explicit opt-out -> insecure
 
 
 def test_login_makes_session_permanent(logged_in_client):

--- a/views/home_view.py
+++ b/views/home_view.py
@@ -96,9 +96,16 @@ def _strip_trailing_slash(url: str) -> str:
 
 
 def _login_error(title: str, message) -> Response:
-    """Redirect to logout with an error."""
+    """Redirect to logout with an error, retaining the entered
+    username and JPS URL (never the password) for re-display."""
     return redirect(
-        url_for(LOGOUT_ENDPOINT, error_title=title, error_message=message)
+        url_for(
+            LOGOUT_ENDPOINT,
+            error_title=title,
+            error_message=message,
+            prev_username=request.form.get("username", ""),
+            prev_url=request.form.get("url", ""),
+        )
     )
 
 
@@ -214,11 +221,18 @@ def _load_server_config() -> dict:
 
 
 def _render_home(error_title="", error_message="", **kwargs) -> str:
-    """Render the home template with common error parameters."""
+    """Render the home template with common error parameters.
+
+    prev_username/prev_url are read from the request args so a failed
+    login can re-populate those fields (never the password). Reading
+    here covers every load_home render branch in one place.
+    """
     return render_template(
         HOME_TEMPLATE,
         error_title=error_title,
         error_message=error_message,
+        prev_username=request.args.get("prev_username", ""),
+        prev_url=request.args.get("prev_url", ""),
         **kwargs,
     )
 

--- a/views/home_view.py
+++ b/views/home_view.py
@@ -231,13 +231,13 @@ def load_home(
 
     server_json = _load_server_config()
     if not server_json:
-        return render_template(HOME_TEMPLATE)
+        return _render_home(error_title, error_message)
 
     brand = server_json.get("brand")
     jps_url = server_json.get("jps_url")
 
     if not jps_url:
-        return _render_home(app_name=brand)
+        return _render_home(error_title, error_message, app_name=brand)
 
     alt_jps = server_json.get("alternate_jps")
     if alt_jps is None:

--- a/views/home_view.py
+++ b/views/home_view.py
@@ -223,16 +223,20 @@ def _load_server_config() -> dict:
 def _render_home(error_title="", error_message="", **kwargs) -> str:
     """Render the home template with common error parameters.
 
-    prev_username/prev_url are read from the request args so a failed
-    login can re-populate those fields (never the password). Reading
-    here covers every load_home render branch in one place.
+    prev_username/prev_url re-populate those fields after a FAILED
+    login only (gated on error_title). This prevents an attacker
+    from crafting a link like ?prev_url=https://evil that pre-fills
+    the JPS URL on a normal page load (credential-target phishing).
+    Password is never retained.
     """
+    prev_username = request.args.get("prev_username", "") if error_title else ""
+    prev_url = request.args.get("prev_url", "") if error_title else ""
     return render_template(
         HOME_TEMPLATE,
         error_title=error_title,
         error_message=error_message,
-        prev_username=request.args.get("prev_username", ""),
-        prev_url=request.args.get("prev_url", ""),
+        prev_username=prev_username,
+        prev_url=prev_url,
         **kwargs,
     )
 

--- a/views/home_view.py
+++ b/views/home_view.py
@@ -96,16 +96,17 @@ def _strip_trailing_slash(url: str) -> str:
 
 
 def _login_error(title: str, message) -> Response:
-    """Redirect to logout with an error, retaining the entered
-    username and JPS URL (never the password) for re-display."""
+    """Redirect to logout with an error. Stash the entered username
+    and JPS URL (never the password) in the session for one-shot
+    re-display on the login page. Using the signed session (not query
+    params) prevents an attacker from crafting a link that pre-fills
+    the JPS URL field (credential-target phishing)."""
+    session["login_retry"] = {
+        "username": request.form.get("username", ""),
+        "url": request.form.get("url", ""),
+    }
     return redirect(
-        url_for(
-            LOGOUT_ENDPOINT,
-            error_title=title,
-            error_message=message,
-            prev_username=request.form.get("username", ""),
-            prev_url=request.form.get("url", ""),
-        )
+        url_for(LOGOUT_ENDPOINT, error_title=title, error_message=message)
     )
 
 
@@ -223,20 +224,18 @@ def _load_server_config() -> dict:
 def _render_home(error_title="", error_message="", **kwargs) -> str:
     """Render the home template with common error parameters.
 
-    prev_username/prev_url re-populate those fields after a FAILED
-    login only (gated on error_title). This prevents an attacker
-    from crafting a link like ?prev_url=https://evil that pre-fills
-    the JPS URL on a normal page load (credential-target phishing).
-    Password is never retained.
+    prev_username/prev_url come from a one-shot session flash set only
+    by _login_error (a genuine failed login), never from request args,
+    so they cannot be attacker-supplied via a crafted URL. Popped on
+    render so they don't persist. Password is never retained.
     """
-    prev_username = request.args.get("prev_username", "") if error_title else ""
-    prev_url = request.args.get("prev_url", "") if error_title else ""
+    retry = session.pop("login_retry", None) or {}
     return render_template(
         HOME_TEMPLATE,
         error_title=error_title,
         error_message=error_message,
-        prev_username=prev_username,
-        prev_url=prev_url,
+        prev_username=retry.get("username", ""),
+        prev_url=retry.get("url", ""),
         **kwargs,
     )
 

--- a/views/resource_view.py
+++ b/views/resource_view.py
@@ -167,13 +167,25 @@ def delete_file() -> Union[Response, Tuple[str, int]]:
             target_file=target_file,
             username=str(escape(session.get("username"))),
         )
-    if target_file:
-        target_file_dir = os.path.dirname(
-            os.path.abspath(os.path.join(files_dir, target_file))
+    if not target_file:
+        logthis.warning(
+            f"[{session.get('url')}] {session.get('username')} "
+            f"attempted a file deletion with no file selected."
         )
-        target_file_path = os.path.abspath(
-            os.path.join(files_dir, target_file)
+        return redirect(
+            url_for(
+                "error",
+                error="No file selected",
+                error_message="Select a file to delete.",
+            )
         )
+
+    target_file_dir = os.path.dirname(
+        os.path.abspath(os.path.join(files_dir, target_file))
+    )
+    target_file_path = os.path.abspath(
+        os.path.join(files_dir, target_file)
+    )
 
     if target_file_dir != files_dir:
         logthis.warning(

--- a/webhook/jawa_receiver.py
+++ b/webhook/jawa_receiver.py
@@ -141,19 +141,6 @@ def webhook_handler(
         return okta_verification.verify_new_webhook(
             request.headers.get("x-okta-verification-challenge")
         )
-    try:
-        webhook_data = request.get_json()
-    except Exception as err:
-        logthis.warning(
-            f"Error loading JSON ({err}). Trying to load from form payload."
-        )
-        webhook_data = json.loads(request.form.get("payload"))
-    if not webhook_data:
-        logthis.warning(
-            f"418.  Error processing /hooks/{webhook_name} - no data provided. I'm a teapot."
-        )
-        return "418 - I'm a teapot.", 418
-    logthis.debug(f"{webhook_name} payload: {webhook_data}")
     if request.method != "POST":
         logthis.warning(
             f"Invalid request, {request.method} for /hooks/{webhook_name}."
@@ -163,6 +150,23 @@ def webhook_handler(
             "Move along.",
             405,
         )
+    try:
+        webhook_data = request.get_json()
+    except Exception as err:
+        logthis.warning(
+            f"Error loading JSON ({err}). Trying to load from form payload."
+        )
+        raw = request.form.get("payload")
+        try:
+            webhook_data = json.loads(raw) if raw else None
+        except (ValueError, TypeError):
+            webhook_data = None
+    if not webhook_data:
+        logthis.warning(
+            f"418.  Error processing /hooks/{webhook_name} - no data provided. I'm a teapot."
+        )
+        return "418 - I'm a teapot.", 418
+    logthis.debug(f"{webhook_name} payload: {webhook_data}")
     webhook_user = "null"
     webhook_pass = "null"
     webhook_apikey = "null"


### PR DESCRIPTION
A batch of six independent, individually-reviewed bug/UX fixes for the v3.2 line. Each is its own commit. Full suite green (90 passed), ruff clean.

## Fixes

- **Local http dev unblocked (J6 follow-up)** — `SESSION_COOKIE_SECURE` is now secure-by-default but can be disabled with `JAWA_INSECURE_COOKIES=1` for local `python3 app.py` runs over http (a Secure cookie is dropped by the browser over http, which caused a login loop). Production (HTTPS behind nginx) is unchanged.
- **Webhook receiver hardening (B2)** — the receiver now returns a deliberate 4xx (405 for wrong method, 418 for malformed/absent body) instead of a 500. The method check runs before body parsing and the form-payload fallback is guarded.
- **Resource deletion (B3)** — deleting with no file selected no longer 500s; it returns a friendly error. The path-traversal containment check is preserved.
- **Branded error pages (B5)** — added 500/403/405 handlers using the redesigned error page. The 500 handler logs the traceback server-side and never leaks it to the response.
- **Login errors surface** — login error messages are now shown on the login page in all render paths (they were dropped for some server-config states).
- **Retain login fields on failure** — a failed login now re-populates the username and Jamf Pro URL (never the password). Implemented via a one-shot server-side session value, so the fields cannot be pre-filled by a crafted URL.

## Tests

New `tests/test_session.py`, `tests/test_resources.py`, `tests/test_error_handlers.py`, and additions to `tests/test_login.py`/`tests/test_receiver.py` cover every fix, including negative cases (malformed payloads, empty selection, no-traceback-leak, and anti-prefill checks). Two previously-`xfail` receiver tests now pass.

## Notes

- Targets `develop` for the batched v3.2 release.
- Known follow-ups logged separately: the `/error` route swaps its title/message args (cosmetic), and a "Setup Required" page needs a direct link to `/setup`.
