### PR TITLE
fix: link the Setup Required error page directly to /setup

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -156,19 +156,24 @@
             {{ error_message }}
         </div>
 
-        {% if link %}
-        <div class="error-link">
-            <a href="{{ link }}" target="_blank">{{ link }}</a>
-        </div>
-        {% endif %}
-
         <div class="error-actions">
             <button type="button" onclick="history.back()" class="btn-error-secondary">
                 ← Back
             </button>
+            {% if link %}
+            {# A supplied link is the recommended next step: make it the
+               primary action (in-page) and demote Dashboard to secondary. #}
+            <a href="{{ link }}" class="btn-error-primary">
+                {{ link_text if link_text else link }} →
+            </a>
+            <a href="/dashboard" class="btn-error-secondary">
+                Dashboard →
+            </a>
+            {% else %}
             <a href="/dashboard" class="btn-error-primary">
                 Dashboard →
             </a>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/tests/test_setup_required.py
+++ b/tests/test_setup_required.py
@@ -1,0 +1,42 @@
+"""The 'Setup Required' error must link the user to /setup.
+
+Creating a jamfpro/okta automation before JAWA is configured raises
+AutomationError("Setup Required", ...). The error page must give the
+admin a direct, in-page way to reach /setup instead of dead-ending.
+"""
+
+import json
+
+
+def _unconfigure_jawa(jawa_env):
+    # Remove jawa_address so get_jawa_address() is falsy -> Setup Required.
+    jawa_env.server_file.write_text(json.dumps({"brand": "JAWA"}))
+
+
+def test_jamfpro_new_without_jawa_links_to_setup(logged_in_client, jawa_env):
+    _unconfigure_jawa(jawa_env)
+    resp = logged_in_client.post(
+        "/automations/jamfpro/new",
+        data={"webhook_name": "test-hook"},
+    )
+    body = resp.data.decode()
+    assert "Setup Required" in body
+    # The page offers a direct link to /setup (the action the user needs).
+    assert 'href="/setup"' in body
+    # Friendly label, not the raw path as the only text.
+    assert "Go to Setup" in body
+    # Internal navigation -- not a new tab.
+    assert 'href="/setup" target="_blank"' not in body
+
+
+def test_okta_new_without_jawa_links_to_setup(logged_in_client, jawa_env):
+    _unconfigure_jawa(jawa_env)
+    # Okta's handler reads the name from "webhookname" (no underscore).
+    resp = logged_in_client.post(
+        "/automations/okta/new",
+        data={"webhookname": "test-okta"},
+    )
+    body = resp.data.decode()
+    assert "Setup Required" in body
+    assert 'href="/setup"' in body
+    assert "Go to Setup" in body

--- a/views/_type_handlers/base.py
+++ b/views/_type_handlers/base.py
@@ -34,11 +34,18 @@ class AutomationError(Exception):
     """Raised when an automation operation fails."""
 
     def __init__(
-        self, title: str, message: str, link: Optional[str] = None
+        self,
+        title: str,
+        message: str,
+        link: Optional[str] = None,
+        link_text: Optional[str] = None,
     ) -> None:
         self.title = title
         self.message = message
         self.link = link
+        # Friendly label for the link when rendered as an action button;
+        # falls back to the raw link if omitted.
+        self.link_text = link_text
         super().__init__(message)
 
 

--- a/views/_type_handlers/jamf_handler.py
+++ b/views/_type_handlers/jamf_handler.py
@@ -183,7 +183,11 @@ class JamfHandler(AutomationHandler):
         server_address = get_jawa_address()
         if not server_address:
             raise AutomationError(
-                "Setup Required", "Please configure JAWA address first."
+                "Setup Required",
+                "Configure your JAWA address and Jamf Pro server "
+                "before creating an automation.",
+                link="/setup",
+                link_text="Go to Setup",
             )
 
         # Ensure token is valid

--- a/views/_type_handlers/okta_handler.py
+++ b/views/_type_handlers/okta_handler.py
@@ -75,7 +75,11 @@ class OktaHandler(AutomationHandler):
         server_address = get_jawa_address()
         if not server_address:
             raise AutomationError(
-                "Setup Required", "Please configure JAWA address first."
+                "Setup Required",
+                "Configure your JAWA address and Jamf Pro server "
+                "before creating an automation.",
+                link="/setup",
+                link_text="Go to Setup",
             )
 
         # Ensure okta verification file is executable

--- a/views/automation_view.py
+++ b/views/automation_view.py
@@ -77,12 +77,15 @@ def _get_session_data() -> dict:
     }
 
 
-def _error_page(title: str, message: str, link: str = None) -> str:
+def _error_page(
+    title: str, message: str, link: str = None, link_text: str = None
+) -> str:
     return render_template(
         "error.html",
         error=title,
         error_message=message,
         link=link,
+        link_text=link_text,
         username=session.get("username"),
     )
 
@@ -175,7 +178,7 @@ def create(auto_type: str) -> Union[Response, str]:
             request.form, request.files, session_data
         )
     except AutomationError as err:
-        return _error_page(err.title, err.message, err.link)
+        return _error_page(err.title, err.message, err.link, err.link_text)
 
     # Persist the entry
     entry = result.get("entry")
@@ -288,7 +291,7 @@ def edit(auto_type: str, name: str) -> Union[Response, str]:
             all_items,
         )
     except AutomationError as err:
-        return _error_page(err.title, err.message, err.link)
+        return _error_page(err.title, err.message, err.link, err.link_text)
 
     return render_template(
         SUCCESS_TEMPLATE,


### PR DESCRIPTION
Creating an automation (jamfpro/okta) before JAWA is configured showed a "Setup Required" error page that dead-ended the user — only Back and Dashboard, with no path to `/setup`, which is exactly where they need to go first (set the FQDN and link a Jamf Pro server).

## Fix

- The "Setup Required" raise sites (`jamf_handler`, `okta_handler`) now pass `link="/setup"` with a friendly label and a clearer message.
- `AutomationError` gains an optional `link_text` for the button label; `_error_page` forwards it.
- `error.html`: when an error carries a link, it renders as the **primary in-page action button** ("Go to Setup →") and Dashboard demotes to secondary. Previously a link was rendered as a raw URL that opened in a new tab. When there's no link, Dashboard stays primary (unchanged).

## Tests

`tests/test_setup_required.py` — asserts the Setup Required page for both jamfpro and okta contains a direct in-page `/setup` link with the "Go to Setup" label (and no `target="_blank"`). Full suite green (92 passed), ruff clean.

Targets `develop` for the batched v3.2 release.
