### PR TITLE
fix: make session-timeout modal survive sleep (absolute deadline + focus re-check)

### DIFF
--- a/templates/shared/_layout.html
+++ b/templates/shared/_layout.html
@@ -137,10 +137,17 @@
 (function () {
     var SESSION_DURATION = {{ session_timeout_seconds | default(900) }};
     var WARNING_BEFORE = 45;
-    var remaining = SESSION_DURATION;
+    // Absolute expiry timestamp (ms). Using a deadline instead of a
+    // decrementing counter makes the timer robust across sleep/tab
+    // throttling: a paused setInterval no longer under-counts. On
+    // return we recompute remaining from the real clock, so an
+    // already-expired session is caught immediately.
+    var deadline = Date.now() + SESSION_DURATION * 1000;
     var warningShown = false;
-    var countdownInterval = null;
     var modal = null;
+    // Session-expired reason, surfaced on the login page after redirect.
+    var EXPIRED_URL = "/logout?error_title=Session+expired"
+        + "&error_message=Please+sign+in+again";
 
     function getModal() {
         if (!modal) {
@@ -150,43 +157,53 @@
         return modal;
     }
 
+    function remainingSeconds() {
+        return Math.round((deadline - Date.now()) / 1000);
+    }
+
     function resetTimer() {
-        remaining = SESSION_DURATION;
+        deadline = Date.now() + SESSION_DURATION * 1000;
         warningShown = false;
-        if (countdownInterval) {
-            clearInterval(countdownInterval);
-            countdownInterval = null;
-        }
         var m = getModal();
         if (m) {
             try { m.hide(); } catch (e) {}
         }
     }
 
-    function showWarning() {
-        warningShown = true;
-        var display = document.getElementById("countdownDisplay");
-        if (display) display.textContent = remaining;
-        var m = getModal();
-        if (m) m.show();
-        countdownInterval = setInterval(function () {
-            remaining--;
-            if (display) display.textContent = Math.max(remaining, 0);
-            if (remaining <= 0) {
-                clearInterval(countdownInterval);
-                window.location.href = "/logout";
-            }
-        }, 1000);
+    function expireNow() {
+        window.location.href = EXPIRED_URL;
     }
 
-    setInterval(function () {
-        if (!warningShown) {
-            remaining--;
-            if (remaining <= WARNING_BEFORE) {
-                showWarning();
+    // Single source of truth, driven by both the interval and by
+    // focus/visibility changes so returning to a slept tab re-evaluates
+    // against the real clock instead of a stale counter.
+    function tick() {
+        var remaining = remainingSeconds();
+        if (remaining <= 0) {
+            // Session already gone (e.g. after a long idle/sleep):
+            // redirect to login with a reason rather than silently.
+            expireNow();
+            return;
+        }
+        if (remaining <= WARNING_BEFORE) {
+            var display = document.getElementById("countdownDisplay");
+            if (display) display.textContent = remaining;
+            if (!warningShown) {
+                warningShown = true;
+                var m = getModal();
+                if (m) m.show();
             }
         }
-    }, 1000);
+    }
+
+    setInterval(tick, 1000);
+    // Re-check the moment the tab regains focus/visibility — this is
+    // what makes the modal survive sleep, since timers are throttled or
+    // paused while the machine sleeps or the tab is backgrounded.
+    window.addEventListener("focus", tick);
+    document.addEventListener("visibilitychange", function () {
+        if (!document.hidden) tick();
+    });
 
     document.getElementById("staySignedInBtn").addEventListener("click", function () {
         fetch("/dashboard", {method: "GET", credentials: "same-origin"})

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -133,6 +133,24 @@ def test_layout_injects_effective_timeout(logged_in_client, jawa_env):
     assert "3600" in body
 
 
+def test_timeout_modal_is_sleep_robust(logged_in_client, jawa_env):
+    # The modal must track an absolute deadline and re-check on tab
+    # focus/visibility so it survives sleep (a decrementing setInterval
+    # counter pauses while the machine sleeps and under-counts).
+    # This is a structural assertion on the rendered JS; true
+    # sleep-survival is a manual browser check (see DESIGN relic).
+    resp = logged_in_client.get("/dashboard")
+    body = resp.data.decode()
+    # Deadline/real-clock based, not a decrementing counter.
+    assert "Date.now()" in body
+    assert "deadline" in body
+    # Re-evaluates when the tab regains focus / becomes visible.
+    assert "visibilitychange" in body
+    assert 'addEventListener("focus"' in body
+    # An already-expired session redirects to login with a reason.
+    assert "error_title=Session+expired" in body
+
+
 def test_non_dict_server_config_fails_safe(logged_in_client, jawa_env):
     # A hand-edited server.json that isn't a JSON object must not 500
     # every route; it must fall back to the 15-min default.


### PR DESCRIPTION
The session-timeout warning modal never appeared after a long idle: returning to the tab, the next click just bounced to the login page. Root cause — the modal counted down a `setInterval` variable, which browsers pause/throttle during sleep or when a tab is backgrounded. The counter froze while the machine slept, so the warning never fired, while the server-side session expired on schedule.

## Fix

- Track an **absolute expiry timestamp** (`deadline = Date.now() + duration`) instead of a decrementing counter, and recompute remaining time from the real clock.
- Re-evaluate on `focus` and `visibilitychange` — not just the 1s interval — so returning to a slept tab immediately re-checks against the real clock.
- On return: if the session is already expired, redirect to `/logout` with a "Session expired" reason so the login page explains why (reuses the login-error banner) instead of a silent bounce; if within the warning window, show the modal immediately with the correct remaining seconds.
- "Stay Signed In" resets the deadline and pings the server (unchanged behavior).

## Verification

`test_timeout_modal_is_sleep_robust` asserts the rendered JS is deadline/`Date.now()`-based, wires `focus`/`visibilitychange`, and carries the expired-redirect URL. True sleep-survival is a manual browser check (documented): sleep the machine past the timeout, wake, expect an immediate "Session expired" login redirect. Full suite green (93 passed), ruff clean.

Targets `develop` for the batched v3.2 release.
