### PR TITLE
fix: J10 paper-cuts — upload cap, setup slash, shebang, copy, auth guard, error swap

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ from typing import Any, Dict, Tuple, Union
 from bin import logger
 from bin.context_processors import inject_common_vars, register_static_cache_bust
 from bin.view_modifiers import response
-from views.home_view import load_home
+from views.home_view import _strip_trailing_slash, load_home
 
 # Flask logging
 logthis = logger.setup_child_logger("jawa", "app")
@@ -270,12 +270,12 @@ def setup() -> Union[Response, str]:
         logthis.debug(
             f"[{session.get('url')}] {session.get('username')} /setup - POST"
         )
-        server_url = request.form.get("address")
+        server_url = _strip_trailing_slash(request.form.get("address") or "")
         if not server_url:
             return redirect(url_for("setup"))
-        jps_url = request.form.get("jss-lock")
+        jps_url = _strip_trailing_slash(request.form.get("jss-lock") or "")
         jps2_check = request.form.get("alternate-jamf")
-        jps_url2 = request.form.get("alternate")
+        jps_url2 = _strip_trailing_slash(request.form.get("alternate") or "")
         timeout_raw = request.form.get("session_timeout_minutes", "")
         try:
             timeout_val = int(timeout_raw)

--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ app.config.update(
     SESSION_COOKIE_SECURE=_secure_cookies,
     SESSION_COOKIE_HTTPONLY=True,
     SESSION_COOKIE_SAMESITE="Lax",
+    MAX_CONTENT_LENGTH=16 * 1024 * 1024,
 )
 
 

--- a/app.py
+++ b/app.py
@@ -450,8 +450,8 @@ def error() -> Union[Response, str]:
     return render_template(
         "error.html",
         username=session.get("username"),
-        error_message=error_title,
-        error=error_message,
+        error=error_title,
+        error_message=error_message,
     )
 
 

--- a/bin/data_store.py
+++ b/bin/data_store.py
@@ -196,6 +196,16 @@ def save_script(
 
     Returns the absolute path to the saved file.
     """
+    # A JAWA automation script is executed directly by the receiver
+    # (Popen, argv form). Without a shebang the OS cannot pick an
+    # interpreter, so it would fail cryptically at trigger time. Reject
+    # it here so the upload fails clearly instead.
+    head = file_storage.read(2)
+    file_storage.seek(0)
+    if head != b"#!":
+        raise ValueError(
+            "Script must start with a shebang (e.g. #!/bin/bash)."
+        )
     if not os.path.isdir(SCRIPTS_DIR):
         os.mkdir(SCRIPTS_DIR)
     filename = file_storage.filename

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -838,6 +838,7 @@ server {
 
         server_name localhost;
         server_name_in_redirect off;
+        client_max_body_size 16m;
         location / {
                 # First attempt to serve request as file, then
                 proxy_pass http://jawa;
@@ -879,6 +880,7 @@ configure_nginx_ubuntu() {
 
           server_name localhost;
           server_name_in_redirect off;
+          client_max_body_size 16m;
           location / {
                   # First attempt to serve request as file, then
                   proxy_pass http://localhost:8000;

--- a/templates/setup/setup.html
+++ b/templates/setup/setup.html
@@ -92,8 +92,8 @@
                     </div>
 
                     <div class="d-flex justify-content-center container-fluid">
-                        <button type="submit" value="Setup" class="btn btn-jawa btn-padded">
-                            Setup
+                        <button type="submit" value="{{ "Save" if jawa_url else "Setup" }}" class="btn btn-jawa btn-padded">
+                            {{ "Save" if jawa_url else "Setup" }}
                         </button>
                     </div>
 

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -29,3 +29,25 @@ def test_405_renders_branded_page(logged_in_client):
     body = resp.data.decode()
     assert "error-card" in body
     assert "Method not allowed" in body
+
+
+def test_error_route_does_not_swap_title_and_message(logged_in_client):
+    # /error reads ?error=<title>&error_message=<body>. error.html renders
+    # `error` as the h1 title and `error_message` as the body. Assert each
+    # lands in the correct element so a future arg-swap regresses the test.
+    import re
+
+    resp = logged_in_client.get(
+        "/error?error=SwapTitleXYZ&error_message=SwapBodyXYZ"
+    )
+    body = resp.data.decode()
+    # Title belongs in the error-title heading, not the body.
+    title_match = re.search(
+        r'class="error-title"[^>]*>(.*?)</h1>', body, re.DOTALL
+    )
+    assert title_match and "SwapTitleXYZ" in title_match.group(1)
+    # Message belongs in the error-message block.
+    msg_match = re.search(
+        r'class="error-message"[^>]*>(.*?)</div>', body, re.DOTALL
+    )
+    assert msg_match and "SwapBodyXYZ" in msg_match.group(1)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -95,6 +95,45 @@ def test_prev_url_not_reflected_via_logout_error_param(client, jawa_env):
     assert 'value="admin"' not in body
 
 
+def test_login_fails_against_non_jamf_url(client, jawa_env, monkeypatch):
+    # Regression guard for the 3.0.2 report where server.json pointing
+    # at JAWA's own URL let any creds log in. A URL that does not answer
+    # Jamf's token endpoint like Jamf Pro (returns non-JSON) must not
+    # log in. Invert the conftest fake_jamf fixture: the token endpoint
+    # returns a 200 whose .json() raises, so get_token() swallows the
+    # error and never sets session["token"] -> _validate_credentials
+    # bounces to /logout.
+    import requests
+
+    class NotJamfResponse:
+        """A non-Jamf endpoint: HTTP 200 but the body is not JSON."""
+
+        status_code = 200
+
+        def json(self):
+            raise ValueError("not JSON")
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: NotJamfResponse())
+    monkeypatch.setattr(requests, "get", lambda *a, **k: NotJamfResponse())
+
+    resp = client.post(
+        "/login",
+        data={
+            "url": "https://not-jamf.example",
+            "username": "u",
+            "password": "p",  # non-blank, so the blank-password gate passes
+        },
+    )
+    # Must NOT reach the dashboard; token fetch failed, so login bounces
+    # to /logout with the "Could not fetch token" error.
+    assert resp.status_code == 302
+    assert "/dashboard" not in resp.headers.get("Location", "")
+    assert "/logout" in resp.headers.get("Location", "")
+
+
 def test_failed_login_does_not_reflect_script_injection(
     client, jawa_env, fake_jamf
 ):

--- a/tests/test_setup_required.py
+++ b/tests/test_setup_required.py
@@ -40,3 +40,19 @@ def test_okta_new_without_jawa_links_to_setup(logged_in_client, jawa_env):
     assert "Setup Required" in body
     assert 'href="/setup"' in body
     assert "Go to Setup" in body
+
+
+def test_setup_strips_trailing_slashes(logged_in_client, jawa_env):
+    logged_in_client.post(
+        "/setup",
+        data={
+            "address": "https://jawa.example.com/",
+            "jss-lock": "https://jamf.example.com/",
+            "alternate": "https://alt.example.com/",
+            "session_timeout_minutes": "15",
+        },
+    )
+    cfg = json.loads(jawa_env.server_file.read_text())
+    assert cfg["jawa_address"] == "https://jawa.example.com"
+    assert cfg["jps_url"] == "https://jamf.example.com"
+    assert cfg["alternate_jps"] == "https://alt.example.com"

--- a/tests/test_setup_required.py
+++ b/tests/test_setup_required.py
@@ -6,6 +6,23 @@ admin a direct, in-page way to reach /setup instead of dead-ending.
 """
 
 import json
+import re
+
+
+def _submit_button_label(body):
+    """Return the visible label of the setup form's submit button.
+
+    The nav bar and sibling pages also render the word "Setup", so a
+    bare substring check can't distinguish first-time setup from an edit.
+    Extract the submit button's inner text specifically.
+    """
+    match = re.search(
+        r'<button[^>]*type="submit"[^>]*>(.*?)</button>',
+        body,
+        re.DOTALL,
+    )
+    assert match, "setup form should have a submit button"
+    return match.group(1).strip()
 
 
 def _unconfigure_jawa(jawa_env):
@@ -56,3 +73,29 @@ def test_setup_strips_trailing_slashes(logged_in_client, jawa_env):
     assert cfg["jawa_address"] == "https://jawa.example.com"
     assert cfg["jps_url"] == "https://jamf.example.com"
     assert cfg["alternate_jps"] == "https://alt.example.com"
+
+
+def test_setup_button_says_save_when_editing(logged_in_client, jawa_env):
+    jawa_env.server_file.write_text(
+        json.dumps(
+            {
+                "jawa_address": "https://jawa.example.com",
+                "jps_url": "x",
+                "alternate_jps": "",
+            }
+        )
+    )
+    resp = logged_in_client.get("/setup")
+    body = resp.data.decode()
+    # An existing config is being edited -> the button reads "Save".
+    assert _submit_button_label(body) == "Save"
+
+
+def test_setup_button_says_setup_when_unconfigured(logged_in_client, jawa_env):
+    jawa_env.server_file.write_text(
+        json.dumps({"jawa_address": "", "jps_url": "", "alternate_jps": ""})
+    )
+    resp = logged_in_client.get("/setup")
+    body = resp.data.decode()
+    # First-time setup keeps the "Setup" affordance on the button itself.
+    assert _submit_button_label(body) == "Setup"

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,4 +1,14 @@
-"""Upload size cap (J10). Flask MAX_CONTENT_LENGTH rejects oversized bodies."""
+"""Upload size cap (J10). Flask MAX_CONTENT_LENGTH rejects oversized bodies.
+
+Also covers shebang validation on automation script uploads (J10): a script
+without a ``#!`` first line must be rejected AT UPLOAD, not cryptically at
+trigger time when the receiver ``Popen``-execs it directly.
+"""
+
+import io
+import os
+
+import pytest
 
 import app as jawa_app
 
@@ -12,7 +22,47 @@ def test_oversized_upload_is_rejected(logged_in_client, jawa_env):
     big = b"x" * (16 * 1024 * 1024 + 1024)
     resp = logged_in_client.post(
         "/resources/files",
-        data={"upload": (__import__("io").BytesIO(big), "big.txt")},
+        data={"upload": (io.BytesIO(big), "big.txt")},
         content_type="multipart/form-data",
     )
     assert resp.status_code == 413
+
+
+class _FakeFile:
+    """Minimal werkzeug FileStorage stand-in backed by bytes."""
+
+    def __init__(self, filename, content):
+        self.filename = filename
+        self._stream = io.BytesIO(content)
+
+    def read(self, n=-1):
+        return self._stream.read(n)
+
+    def seek(self, pos, whence=0):
+        return self._stream.seek(pos, whence)
+
+    def save(self, path):
+        self._stream.seek(0)
+        with open(path, "wb") as f:
+            f.write(self._stream.read())
+
+
+def test_save_script_rejects_missing_shebang(jawa_env):
+    from bin import data_store
+
+    bad = _FakeFile("noshebang.sh", b"echo hello\n")
+    with pytest.raises(ValueError):
+        data_store.save_script(bad, "test")
+    # Nothing should have been written for a rejected upload.
+    assert os.listdir(data_store.SCRIPTS_DIR) == []
+
+
+def test_save_script_accepts_shebang(jawa_env):
+    from bin import data_store
+
+    good = _FakeFile("good.sh", b"#!/bin/bash\necho hi\n")
+    path = data_store.save_script(good, "test")
+    assert os.path.exists(path)
+    # The rewind must let save() write the FULL file, not just the tail.
+    with open(path, "rb") as f:
+        assert f.read() == b"#!/bin/bash\necho hi\n"

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,0 +1,18 @@
+"""Upload size cap (J10). Flask MAX_CONTENT_LENGTH rejects oversized bodies."""
+
+import app as jawa_app
+
+
+def test_max_content_length_is_set_to_16mb():
+    assert jawa_app.app.config.get("MAX_CONTENT_LENGTH") == 16 * 1024 * 1024
+
+
+def test_oversized_upload_is_rejected(logged_in_client, jawa_env):
+    # A body over 16 MB must be rejected (413), not silently accepted.
+    big = b"x" * (16 * 1024 * 1024 + 1024)
+    resp = logged_in_client.post(
+        "/resources/files",
+        data={"upload": (__import__("io").BytesIO(big), "big.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 413

--- a/views/automation_view.py
+++ b/views/automation_view.py
@@ -179,6 +179,9 @@ def create(auto_type: str) -> Union[Response, str]:
         )
     except AutomationError as err:
         return _error_page(err.title, err.message, err.link, err.link_text)
+    except ValueError as err:
+        # e.g. save_script rejecting an upload with no shebang.
+        return _error_page("Invalid script", str(err))
 
     # Persist the entry
     entry = result.get("entry")
@@ -292,6 +295,9 @@ def edit(auto_type: str, name: str) -> Union[Response, str]:
         )
     except AutomationError as err:
         return _error_page(err.title, err.message, err.link, err.link_text)
+    except ValueError as err:
+        # e.g. save_script rejecting an upload with no shebang.
+        return _error_page("Invalid script", str(err))
 
     return render_template(
         SUCCESS_TEMPLATE,


### PR DESCRIPTION
The J10 paper-cuts batch (internal ref **J10**) — six small, individually-reviewed fixes. Full suite green (102 passed), ruff clean.

## Fixes

- **Upload size cap (16 MB)** — Flask `MAX_CONTENT_LENGTH` + `client_max_body_size 16m` in JAWA's nginx vhost (both installer server blocks). Fixes the opaque failure when uploads hit nginx's silent 1 MB default. ⚠️ **installer change — needs a manual fresh-VM install test before this reaches `main`** (main is production for `bin/installer.sh`).
- **`/setup` trailing-slash strip** — `address`/`jss-lock`/`alternate` are stripped before saving, so Jamf webhook URLs no longer get double slashes.
- **Shebang validation** — script uploads without a `#!` are rejected at upload with a friendly error, instead of failing cryptically at trigger time (the receiver execs the file directly).
- **Setup button copy** — reads "Save" when editing an existing config, "Setup" on first-time setup.
- **Auth regression guard** — a test locking in that login fails against a URL that doesn't answer like Jamf Pro (guards the old 3.0.2 "any creds" report).
- **`/error` route** — no longer swaps the title and message when rendering the branded error page.

## Notes

- Known follow-up logged: no branded 413 page yet (oversized uploads get Flask's default 413 — functionally correct, UX follow-up).
- Targets `develop` for the batched v3.2 release.
